### PR TITLE
Fix a bug surrounding the reading of prop blueprints

### DIFF
--- a/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Prop.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Prop.cs
@@ -79,6 +79,7 @@ public partial struct GetGamedataFile
 
 				StoredPrefab = NewProp;
 
+				Debug.Log(BP);
 				if (BP.LODs.Length > 0)
 				{
 					if (BP.LODs[0].Mesh)
@@ -251,9 +252,10 @@ public partial struct GetGamedataFile
 		}
 
 		BluePrintString = BluePrintString.Replace("PropBlueprint {", "PropBlueprint = {");
+        BluePrintString = BluePrintString.Replace("PropBlueprint{", "PropBlueprint = {");
 
-		// *** Parse Blueprint
-		ToReturn.BP = new PropBluePrint();
+        // *** Parse Blueprint
+        ToReturn.BP = new PropBluePrint();
 		// Create Lua
 		Lua BP = new Lua();
 		BP.LoadCLRPackage();

--- a/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Prop.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Prop.cs
@@ -79,7 +79,6 @@ public partial struct GetGamedataFile
 
 				StoredPrefab = NewProp;
 
-				Debug.Log(BP);
 				if (BP.LODs.Length > 0)
 				{
 					if (BP.LODs[0].Mesh)


### PR DESCRIPTION
Because of https://github.com/FAForever/fa/pull/6272 and https://github.com/FAForever/fa/pull/6274 the formatting of prop blueprints have changed. And specifically the ` ` between `PropBlueprint` and `{` is now gone. As a result the original replacement no longer worked.

