### PR TITLE
Add vsconfig to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio config file
+.vsconfig
+
 # Rider directory
 .idea
 


### PR DESCRIPTION
If I understand this correctly then vsconfig stores local configuration of the visual studio install and thus should not be version controlled.