### PR TITLE
Make FAF directory configurable

### DIFF
--- a/Assets/Scripts/Ozone SCMAP Code/EnvPaths.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/EnvPaths.cs
@@ -6,12 +6,14 @@ public class EnvPaths : MonoBehaviour {
 
 	public static string DefaultMapPath;
 	public static string DefaultGamedataPath;
+	public static string DefaultFafDataPath;
 
 	static Microsoft.Win32.RegistryKey regKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall");
 	//static RegistryKey regKey = Registry. .OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall");
 
 
 	const string InstallationPath = "InstallationPath";
+	const string FafDataPath = "FafDataPath";
 	const string InstallationGamedata = "gamedata/";
 	const string InstallationMods = "mods/";
 	const string MapsPath = "MapsPath";
@@ -37,19 +39,43 @@ public class EnvPaths : MonoBehaviour {
 		{
 			GenericInfoPopup.ShowInfo("Wrong game installation path!\nCheck preferences.");
 		}
-	}
+    }
 
-	/// <summary>
-	/// All directorys from where editor will load *.scd and *.nx2 files
-	/// </summary>
-	public static string[] LoadGamedataPaths
+    public static string GetFafDataPath()
+    {
+        return PlayerPrefs.GetString(FafDataPath, EnvPaths.DefaultFafDataPath);
+    }
+
+    public static void SetFafDataPath(string value)
+    {
+        value = value.Replace("\\", "/");
+        if (value[value.Length - 1].ToString() != "/") value += "/";
+        if (value[0].ToString() == "/") value = value.Remove(0, 1);
+
+        if (value.ToLower().EndsWith(InstallationGamedata))
+        {
+            value = value.Remove(value.Length - InstallationGamedata.Length);
+        }
+
+        PlayerPrefs.SetString(FafDataPath, value);
+
+        if (!System.IO.Directory.Exists(value))
+        {
+            GenericInfoPopup.ShowInfo("Wrong game installation path!\nCheck preferences.");
+        }
+    }
+
+    /// <summary>
+    /// All directorys from where editor will load *.scd and *.nx2 files
+    /// </summary>
+    public static string[] LoadGamedataPaths
 	{
 		get
 		{
 			if(AllowMods)
-				return new string[] { GamedataPath, FAFGamedataPath, GamedataModsPath, UserModsPath };
+				return new string[] { GamedataPath, FAFDataPath, GamedataModsPath, UserModsPath };
 
-			return new string[] { GamedataPath, FAFGamedataPath };
+			return new string[] { GamedataPath, FAFDataPath };
 		}
 	}
 
@@ -92,12 +118,12 @@ public class EnvPaths : MonoBehaviour {
 		}
 	}
 
-	public static string FAFGamedataPath
+	public static string FAFDataPath
 	{
 		get
 		{
-			return EnvPaths.ProgramData + "/FAForever/gamedata/";
-		}
+            return GetFafDataPath() + InstallationGamedata;
+        }
 	}
 
 	public static string CurrentGamedataPath = "";
@@ -140,18 +166,28 @@ public class EnvPaths : MonoBehaviour {
 	#region Auto Generate
 	public static void GenerateDefaultPaths() {
 		GenerateMapPath();
+		GenerateFafDataPath();
 		GenerateGamedataPath();
 	}
 
 	public static void GenerateMapPath() {
 		DefaultMapPath = MyDocuments.Replace("\\", "/") + "/My Games/Gas Powered Games/Supreme Commander Forged Alliance/Maps/";
 		if (!System.IO.Directory.Exists(DefaultMapPath)) {
-			Debug.LogWarning("Default map directory not exist: " + DefaultMapPath);
+			Debug.LogWarning("Default map directory does not exist: " + DefaultMapPath);
 			DefaultMapPath = "maps/";
 		}
 	}
+    public static void GenerateFafDataPath()
+    {
+        DefaultFafDataPath = EnvPaths.ProgramData + "/FAForever/";
+        if (!System.IO.Directory.Exists(DefaultMapPath))
+        {
+            Debug.LogWarning("Default FAF directory does not exist: " + DefaultFafDataPath);
+            DefaultFafDataPath = "";
+        }
+    }
 
-	public static void GenerateGamedataPath() {
+    public static void GenerateGamedataPath() {
 		DefaultGamedataPath = FindByDisplayName(regKey, "Supreme Commander: Forged Alliance").Replace("\\", "/");
 
 
@@ -161,7 +197,7 @@ public class EnvPaths : MonoBehaviour {
 				DefaultGamedataPath += "/";
 
 			if (!System.IO.Directory.Exists(DefaultGamedataPath)) {
-				Debug.LogWarning("Instalation directory not exist: " + DefaultGamedataPath);
+				Debug.LogWarning("Installation directory does not exist: " + DefaultGamedataPath);
 				DefaultGamedataPath = "";
 			}
 		}

--- a/Assets/Scripts/Ozone SCMAP Code/EnvPaths.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/EnvPaths.cs
@@ -11,27 +11,27 @@ public class EnvPaths : MonoBehaviour {
 	//static RegistryKey regKey = Registry. .OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall");
 
 
-	const string InstalationPath = "InstalationPath";
-	const string InstalationGamedata = "gamedata/";
-	const string InstalationMods = "mods/";
+	const string InstallationPath = "InstallationPath";
+	const string InstallationGamedata = "gamedata/";
+	const string InstallationMods = "mods/";
 	const string MapsPath = "MapsPath";
 	const string BackupPath = "BackupPath";
 
-	public static string GetInstalationPath() {
-		return PlayerPrefs.GetString(InstalationPath, EnvPaths.DefaultGamedataPath);
+	public static string GetInstallationPath() {
+		return PlayerPrefs.GetString(InstallationPath, EnvPaths.DefaultGamedataPath);
 	}
 
-	public static void SetInstalationPath(string value) {
+	public static void SetInstallationPath(string value) {
 		value = value.Replace("\\", "/");
 		if (value[value.Length - 1].ToString() != "/") value += "/";
 		if (value[0].ToString() == "/") value = value.Remove(0, 1);
 
-		if (value.ToLower().EndsWith(InstalationGamedata))
+		if (value.ToLower().EndsWith(InstallationGamedata))
 		{
-			value = value.Remove(value.Length - InstalationGamedata.Length);
+			value = value.Remove(value.Length - InstallationGamedata.Length);
 		}
 
-		PlayerPrefs.SetString(InstalationPath, value);
+		PlayerPrefs.SetString(InstallationPath, value);
 
 		if (!System.IO.Directory.Exists(value))
 		{
@@ -72,7 +72,7 @@ public class EnvPaths : MonoBehaviour {
 	public static string GamedataPath{
 		get
 		{
-			return GetInstalationPath() + InstalationGamedata;
+			return GetInstallationPath() + InstallationGamedata;
 		}
 	}
 
@@ -80,7 +80,7 @@ public class EnvPaths : MonoBehaviour {
 	{
 		get
 		{
-			return GetInstalationPath() + InstalationMods;
+			return GetInstallationPath() + InstallationMods;
 		}
 	}
 

--- a/Assets/Scripts/Ozone SCMAP Code/MapLuaParser.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/MapLuaParser.cs
@@ -94,10 +94,10 @@ public partial class MapLuaParser : MonoBehaviour
 
 		EnvPaths.GenerateDefaultPaths();
 
-		if (string.IsNullOrEmpty(EnvPaths.GetInstalationPath()))
+		if (string.IsNullOrEmpty(EnvPaths.GetInstallationPath()))
 		{
 			EnvPaths.GenerateGamedataPath();
-			EnvPaths.SetInstalationPath(EnvPaths.DefaultGamedataPath);
+			EnvPaths.SetInstallationPath(EnvPaths.DefaultGamedataPath);
 		}
 
 		StructurePath = GetDataPath() + "/Structure/";

--- a/Assets/Scripts/Ozone SCMAP Code/MapLuaParser_App.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/MapLuaParser_App.cs
@@ -9,24 +9,13 @@ public partial class MapLuaParser : MonoBehaviour
 	void Start () {
 		Args = System.Environment.GetCommandLineArgs();
 
-		/*
-		for(int i = 0; i < Args.Length; i++)
-		{
-			Debug.Log(Args[i]);
-		}
-		*/
-
 		if (Args.Length > 0)
 
-			if (Args.Length == 3 && Args[1] == "-setInstalationPath")
+			if (Args.Length == 3 && Args[1] == "-setInstallationPath")
 			{
-				EnvPaths.SetInstalationPath(Args[2]);
-				//Debug.Log("Success! Instalation path changed to: " + Args[2]);
+				EnvPaths.SetInstallationPath(Args[2]);
 			}
 
-
-		//Debug.Log(Args.Length);
-		//Debug.Log(Args[0]);
 		if (Args.Length >= 6)
 		{
 			if (Args[1] == "-renderPreviewImage" || Args[1] == "-renderPreviewImageNoProps" || Args[1] == "-renderPreviewImageNoDecals" || Args[1] == "-renderPreviewImageNoPropsDecals")

--- a/Assets/Scripts/UI/AppMenu/AppMenu.cs
+++ b/Assets/Scripts/UI/AppMenu/AppMenu.cs
@@ -199,11 +199,11 @@ public partial class AppMenu : MonoBehaviour
 					if (!FafEditorSettings.GetFogOfWar())
 						Arguments += " /nofog";
 
-					string GamePath = EnvPaths.GetInstalationPath() + "bin/SupremeCommander.exe";
+					string GamePath = EnvPaths.GetInstallationPath() + "bin/SupremeCommander.exe";
 
 					if (!System.IO.File.Exists(GamePath))
 					{
-						string OtherPath = EnvPaths.GetInstalationPath() + "bin/ForgedAlliance.exe";
+						string OtherPath = EnvPaths.GetInstallationPath() + "bin/ForgedAlliance.exe";
 						if (System.IO.File.Exists(OtherPath))
 						{
 							GamePath = OtherPath;
@@ -211,7 +211,7 @@ public partial class AppMenu : MonoBehaviour
 						else
 						{
 
-							Debug.LogWarning("Game executable not exist at given path: " + EnvPaths.GetInstalationPath() + "bin/");
+							Debug.LogWarning("Game executable not exist at given path: " + EnvPaths.GetInstallationPath() + "bin/");
 							return;
 						}
 					}

--- a/Assets/Scripts/UI/Windows/FafEditorSettings.cs
+++ b/Assets/Scripts/UI/Windows/FafEditorSettings.cs
@@ -27,7 +27,7 @@ public class FafEditorSettings : MonoBehaviour
 
 	void OnEnable()
 	{
-		PathField.text = EnvPaths.GetInstalationPath();
+		PathField.text = EnvPaths.GetInstallationPath();
 		MapsPathField.text = EnvPaths.GetMapsPath();
 		BackupPathField.text = EnvPaths.GetBackupPath();
 
@@ -66,7 +66,7 @@ public class FafEditorSettings : MonoBehaviour
 		}
 		else
 		{
-			EnvPaths.SetInstalationPath(PathField.text);
+			EnvPaths.SetInstallationPath(PathField.text);
 		}
 
 		if (string.IsNullOrEmpty(MapsPathField.text))

--- a/Assets/Scripts/UI/Windows/FafEditorSettings.cs
+++ b/Assets/Scripts/UI/Windows/FafEditorSettings.cs
@@ -10,6 +10,7 @@ public class FafEditorSettings : MonoBehaviour
 {
 
 	public InputField PathField;
+	public InputField FafPathField;
 	public InputField MapsPathField;
 	public InputField BackupPathField;
 	public Slider HistorySlider;
@@ -28,6 +29,7 @@ public class FafEditorSettings : MonoBehaviour
 	void OnEnable()
 	{
 		PathField.text = EnvPaths.GetInstallationPath();
+		FafPathField.text = EnvPaths.GetFafDataPath();
 		MapsPathField.text = EnvPaths.GetMapsPath();
 		BackupPathField.text = EnvPaths.GetBackupPath();
 
@@ -69,7 +71,16 @@ public class FafEditorSettings : MonoBehaviour
 			EnvPaths.SetInstallationPath(PathField.text);
 		}
 
-		if (string.IsNullOrEmpty(MapsPathField.text))
+        if (string.IsNullOrEmpty(FafPathField.text))
+        {
+            GenericInfoPopup.ShowInfo("FAF data path can't be empty!");
+        }
+        else
+        {
+            EnvPaths.SetFafDataPath(FafPathField.text);
+        }
+
+        if (string.IsNullOrEmpty(MapsPathField.text))
 		{
 			GenericInfoPopup.ShowInfo("Maps folder path can't be empty!");
 		}
@@ -124,9 +135,20 @@ public class FafEditorSettings : MonoBehaviour
 		{
 			PathField.text = paths[0];
 		}
-	}
+    }
 
-	public void BrowseMapPath()
+    public void BrowseFafDataPath()
+    {
+
+        var paths = StandaloneFileBrowser.OpenFolderPanel("Select Forged Alliance Forever data path", EnvPaths.GetFafDataPath(), false);
+
+        if (paths.Length > 0 && !string.IsNullOrEmpty(paths[0]))
+        {
+            FafPathField.text = paths[0];
+        }
+    }
+
+    public void BrowseMapPath()
 	{
 
 		var paths = StandaloneFileBrowser.OpenFolderPanel("Select 'Maps' folder.", EnvPaths.GetMapsPath(), false);
@@ -152,10 +174,14 @@ public class FafEditorSettings : MonoBehaviour
 	{
 		EnvPaths.GenerateGamedataPath();
 		PathField.text = EnvPaths.DefaultGamedataPath;
-
 	}
+    public void ResetFafData()
+    {
+        EnvPaths.GenerateFafDataPath();
+        FafPathField.text = EnvPaths.DefaultFafDataPath;
+    }
 
-	public void ResetMap()
+    public void ResetMap()
 	{
 		EnvPaths.GenerateMapPath();
 		MapsPathField.text = EnvPaths.DefaultMapPath;


### PR DESCRIPTION
The faf client lets you move the faf data directory. The editor assumes it to be always at the same path. So to not break the editor when you are using the client functionality the editor can now use a custom path as well.

![grafik](https://github.com/user-attachments/assets/a72b8d27-dc05-4aa7-abb2-74256d83ff4e)

