### PR TITLE
Add Terrain351 shader

### DIFF
--- a/Assets/GFX/Shaders/Deferred/Internal-DeferredShading.shader
+++ b/Assets/GFX/Shaders/Deferred/Internal-DeferredShading.shader
@@ -230,8 +230,10 @@ half4 CalculateLight (unity_v2f_deferred i)
         color.rgb = CalculateLighting(worldNormal, eyeVec, albedo, 1-alpha, atten);
     } else if (_ShaderID == 1) {
         color.rgb = CalculateXPLighting(worldNormal, eyeVec, float4(albedo, alpha), atten);
-    } else if (_ShaderID == 2) {
+    } else if (_ShaderID == 2 || _ShaderID == 3) {
         color.rgb = PBR(wpos, eyeVec, albedo, worldNormal, roughness, mapShadow * atten);
+    } else {
+        color.rgb = albedo;
     }
 
     if (_Water) {

--- a/Assets/GFX/Shaders/FaTerrainShader.shader
+++ b/Assets/GFX/Shaders/FaTerrainShader.shader
@@ -711,7 +711,18 @@
                     o.wNormal = normalize(normal);
 
                     o.WaterDepth = tex2D(UpperAlbedoSampler, position.xy).b;
-                 
+                    o.MapShadow = tex2D(UpperAlbedoSampler, position.xy).w;
+                }
+                else if (_ShaderID == 3)
+                {
+                    float4 albedo = Terrain301AlbedoPS(inV, false);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain301NormalsPS(inV, false).xyz);
+                    o.wNormal = normalize(normal);
+
+                    o.WaterDepth = tex2D(UpperAlbedoSampler, position.xy).b;
                     o.MapShadow = tex2D(UpperAlbedoSampler, position.xy).w;
                 }
                 else {

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -1096,8 +1096,13 @@ public partial class ScmapEditor : MonoBehaviour
 		else if (MapLuaParser.Current.EditMenu.TexturesMenu.ShaderName.text == "Terrain301")
 		{
 			Shader.SetGlobalInt("_ShaderID", 2);
-		} else
-		{
+		}
+        else if (MapLuaParser.Current.EditMenu.TexturesMenu.ShaderName.text == "Terrain351")
+        {
+            Shader.SetGlobalInt("_ShaderID", 3);
+        }
+        else
+        {
             Shader.SetGlobalInt("_ShaderID", -1);
         }
 	}

--- a/Assets/Scripts/UI/UiElements/UiTextField.cs
+++ b/Assets/Scripts/UI/UiElements/UiTextField.cs
@@ -93,7 +93,7 @@ namespace Ozone.UI
 			if (ChangingValue)
 				return;
 			InvokeStart();
-			UpdateSliderValue(true);
+			UpdateSliderValue();
 			OnEndEdit.Invoke();
 			SetTextField();
 			Started = false;
@@ -148,7 +148,7 @@ namespace Ozone.UI
 		#endregion
 
 
-		void UpdateSliderValue(bool ClampText = false)
+		void UpdateSliderValue()
 		{
 			ChangingValue = true;
 			HasValue = true;
@@ -163,15 +163,7 @@ namespace Ozone.UI
 
 			if (SliderUi)
 			{
-				LastValue = Mathf.Clamp(LastValue, SliderUi.minValue, SliderUi.maxValue);
-
-				if (ClampText)
-				{
-					SetTextField();
-				}
-
 				SliderUi.value = LastValue;
-
 			}
 
 			ChangingValue = false;
@@ -194,7 +186,6 @@ namespace Ozone.UI
 			LastValue = value;
 			if (SliderUi)
 			{
-				LastValue = Mathf.Clamp(LastValue, SliderUi.minValue, SliderUi.maxValue);
 				SliderUi.value = LastValue;
 			}
 
@@ -209,7 +200,6 @@ namespace Ozone.UI
 			LastValue = value;
 			if (SliderUi)
 			{
-				LastValue = Mathf.Clamp(LastValue, SliderUi.minValue, SliderUi.maxValue);
 				SliderUi.value = LastValue;
 			}
 			SetTextField();


### PR DESCRIPTION
This is the same as Terrain301, it just uses the full mask range.
I also disabled the clamping of slider values. You can now input arbitrary values in the text box above a slider. This is important for things like the light multiplier that needs to be bigger than 2.1 to trigger the advanced water shader.
Before this change, if you loaded such a map and clicked on the light tab, the value would silently be clamped to 2.0
![grafik](https://github.com/user-attachments/assets/c0c0e786-ab6b-4809-bc90-21fff4ee6dc0)
