### PR TITLE
Improved water settings

### DIFF
--- a/Assets/Scripts/Ozone SCMAP Code/MapLuaParser.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/MapLuaParser.cs
@@ -124,6 +124,8 @@ public partial class MapLuaParser : MonoBehaviour
 		ScenarioFileName = "";
 
 		EditMenu.TexturesMenu.ResetVisibility();
+		EditMenu.WaterMenu.AdvancedWaterToggle.isOn = false;
+		EditMenu.WaterMenu.UseLightingSettings.isOn = false;
 
 		ResourceBrowser.Current.gameObject.SetActive(false);
 	}

--- a/Assets/Scripts/UI/Editing.cs
+++ b/Assets/Scripts/UI/Editing.cs
@@ -20,6 +20,7 @@ namespace EditMap
 		public MapInfo MapInfoMenu;
 		public StratumInfo TexturesMenu;
 		public LightingInfo LightingMenu;
+		public WaterInfo WaterMenu;
 
 		[Header("State")]
 		public bool MauseOnGameplay;

--- a/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
+++ b/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
@@ -242,22 +242,14 @@ namespace EditMap
 			LoadValues();
         }
 
-		public void ResetSun()
+		public void ResetLight()
 		{
 			BeginUpdateMenu();
 
-			RA.SetValue(-48);
+			RA.SetValue(312);
 			DA.SetValue(34);
 			LightMultipiler.SetValue(1.54f);
 			LightColor.SetColorField(new Color(1.38f, 1.29f, 1.14f, 1));
-
-			UpdateMenu();
-		}
-
-		public void ResetAmbient()
-		{
-			BeginUpdateMenu();
-
 			AmbienceColor.SetColorField(Color.black);
 			ShadowColor.SetColorField(new Color(0.54f, 0.54f, 0.7f));
 

--- a/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
+++ b/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
@@ -51,8 +51,9 @@ namespace EditMap
 			Quaternion CheckRot = Scmap.Sun.transform.rotation;
 
 			float RaHold = CheckRot.eulerAngles.y;
-			if (RaHold > 180) RaHold -= 360;
-			if (RaHold < -180) RaHold += 360;
+			RaHold += 180;
+			if (RaHold > 360) RaHold -= 360;
+			if (RaHold < 0) RaHold += 360;
 			RaHold *= 10;
 			RaHold = (int)RaHold;
 			RaHold /= 10f;
@@ -171,7 +172,7 @@ namespace EditMap
 		{
 			if (Scmap.map == null) return;
 
-			Scmap.Sun.transform.rotation = Quaternion.Euler(new Vector3(DA.value, -360 + RA.value, 0));
+			Scmap.Sun.transform.rotation = Quaternion.Euler(new Vector3(DA.value, -180 + RA.value, 0));
 			Vector3 SunDir = Scmap.Sun.transform.rotation * Vector3.back;
 			SunDir.z *= -1;
 			Scmap.map.SunDirection = SunDir;

--- a/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
+++ b/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
@@ -200,6 +200,11 @@ namespace EditMap
 
 			Scmap.map.Bloom = Bloom.value;
 
+			if (MapLuaParser.Current.EditMenu.WaterMenu.UseLightingSettings.isOn)
+			{
+				MapLuaParser.Current.EditMenu.WaterMenu.WaterSettingsChanged(false);
+            }
+
 			Scmap.UpdateLighting();
 			Scmap.Skybox.LoadSkybox();
 

--- a/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
@@ -1,10 +1,7 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 using Ozone.UI;
 using System.IO;
-using System.Runtime.InteropServices;
 using SFB;
 
 namespace EditMap
@@ -27,6 +24,8 @@ namespace EditMap
 		public UiTextField ColorLerpYElevation;
 		public UiColor WaterColor;
 		public UiColor SunColor;
+		public Toggle UseLightingSettings;
+		private Vector3 SunDirection;
 
 		public UiTextField SunShininess;
 
@@ -63,8 +62,8 @@ namespace EditMap
 			ColorLerpXElevation.SetValue(ScmapEditor.Current.map.Water.ColorLerp.x);
 			ColorLerpYElevation.SetValue(ScmapEditor.Current.map.Water.ColorLerp.y);
 
-			WaterColor.SetColorField(ScmapEditor.Current.map.Water.SurfaceColor.x, ScmapEditor.Current.map.Water.SurfaceColor.y, ScmapEditor.Current.map.Water.SurfaceColor.z); // WaterSettingsChanged
-			SunColor.SetColorField(ScmapEditor.Current.map.Water.SunColor.x, ScmapEditor.Current.map.Water.SunColor.y, ScmapEditor.Current.map.Water.SunColor.z); // WaterSettingsChanged
+			WaterColor.SetColorField(ScmapEditor.Current.map.Water.SurfaceColor.x, ScmapEditor.Current.map.Water.SurfaceColor.y, ScmapEditor.Current.map.Water.SurfaceColor.z);
+            SunColor.SetColorField(ScmapEditor.Current.map.Water.SunColor.x, ScmapEditor.Current.map.Water.SunColor.y, ScmapEditor.Current.map.Water.SunColor.z);
 
 			SunShininess.SetValue(ScmapEditor.Current.map.Water.SunShininess);
 
@@ -174,11 +173,21 @@ namespace EditMap
 			if (Loading)
 				return;
 
+            if (UseLightingSettings.isOn)
+            {
+                SunColor.SetColorField(ScmapEditor.Current.map.SunColor.x * ScmapEditor.Current.map.LightingMultiplier, 
+									   ScmapEditor.Current.map.SunColor.y * ScmapEditor.Current.map.LightingMultiplier, 
+									   ScmapEditor.Current.map.SunColor.z * ScmapEditor.Current.map.LightingMultiplier);
+                SunDirection = ScmapEditor.Current.map.SunDirection;
+            } else {
+                SunDirection = new Vector3(0.09954818f, -0.9626309f, 0.2518569f);
+            }
 
-			bool AnyChanged = ScmapEditor.Current.map.Water.ColorLerp.x != ColorLerpXElevation.value
+            bool AnyChanged = ScmapEditor.Current.map.Water.ColorLerp.x != ColorLerpXElevation.value
 				|| ScmapEditor.Current.map.Water.ColorLerp.y != ColorLerpYElevation.value
 				|| ScmapEditor.Current.map.Water.SurfaceColor != WaterColor.GetVectorValue()
 				|| ScmapEditor.Current.map.Water.SunColor != SunColor.GetVectorValue()
+				|| ScmapEditor.Current.map.Water.SunDirection != SunDirection
 				|| ScmapEditor.Current.map.Water.SunShininess != SunShininess.value
 				|| ScmapEditor.Current.map.Water.UnitReflection != UnitReflection.value
 				|| ScmapEditor.Current.map.Water.SkyReflection != SkyReflection.value
@@ -208,6 +217,7 @@ namespace EditMap
 
 			ScmapEditor.Current.map.Water.SurfaceColor = WaterColor.GetVectorValue();
 			ScmapEditor.Current.map.Water.SunColor = SunColor.GetVectorValue();
+			ScmapEditor.Current.map.Water.SunDirection = SunDirection;
 
 			ScmapEditor.Current.map.Water.SunShininess = SunShininess.value;
 

--- a/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
@@ -19,6 +19,7 @@ namespace EditMap
 		public UiTextField WaterElevation;
 		public UiTextField DepthElevation;
 		public UiTextField AbyssElevation;
+		public Toggle AdvancedWaterToggle;
 
 		public UiTextField ColorLerpXElevation;
 		public UiTextField ColorLerpYElevation;
@@ -48,6 +49,18 @@ namespace EditMap
 
 		private void OnDisable()
 		{
+		}
+
+		public void OnWaterTogglePressed()
+		{
+			if (AdvancedWaterToggle.isOn)
+			{
+				MapLuaParser.Current.EditMenu.LightingMenu.RecalculateLightSettings(2.2f);
+            } 
+			else
+			{
+                MapLuaParser.Current.EditMenu.LightingMenu.RecalculateLightSettings(1.8f);
+            }
 		}
 
 		public void ReloadValues(bool Undo = false)
@@ -175,10 +188,11 @@ namespace EditMap
 
             if (UseLightingSettings.isOn)
             {
-                SunColor.SetColorField(ScmapEditor.Current.map.SunColor.x * ScmapEditor.Current.map.LightingMultiplier, 
-									   ScmapEditor.Current.map.SunColor.y * ScmapEditor.Current.map.LightingMultiplier, 
-									   ScmapEditor.Current.map.SunColor.z * ScmapEditor.Current.map.LightingMultiplier);
-                SunDirection = ScmapEditor.Current.map.SunDirection;
+				Map map = ScmapEditor.Current.map;
+                SunColor.SetColorField(map.SunColor.x * (map.LightingMultiplier - map.ShadowFillColor.x),
+                                       map.SunColor.y * (map.LightingMultiplier - map.ShadowFillColor.y), 
+									   map.SunColor.z * (map.LightingMultiplier - map.ShadowFillColor.z));
+                SunDirection = map.SunDirection;
             } else {
                 SunDirection = new Vector3(0.09954818f, -0.9626309f, 0.2518569f);
             }

--- a/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
@@ -28,12 +28,7 @@ namespace EditMap
 		public UiColor WaterColor;
 		public UiColor SunColor;
 
-		public UiTextField SunStrength;
 		public UiTextField SunShininess;
-		public UiTextField SunReflection;
-
-		public UiTextField FresnelPower;
-		public UiTextField FresnelBias;
 
 		public UiTextField UnitReflection;
 		public UiTextField SkyReflection;
@@ -71,12 +66,7 @@ namespace EditMap
 			WaterColor.SetColorField(ScmapEditor.Current.map.Water.SurfaceColor.x, ScmapEditor.Current.map.Water.SurfaceColor.y, ScmapEditor.Current.map.Water.SurfaceColor.z); // WaterSettingsChanged
 			SunColor.SetColorField(ScmapEditor.Current.map.Water.SunColor.x, ScmapEditor.Current.map.Water.SunColor.y, ScmapEditor.Current.map.Water.SunColor.z); // WaterSettingsChanged
 
-			SunStrength.SetValue(ScmapEditor.Current.map.Water.SunStrength);
 			SunShininess.SetValue(ScmapEditor.Current.map.Water.SunShininess);
-			SunReflection.SetValue(ScmapEditor.Current.map.Water.SunReflection);
-
-			FresnelPower.SetValue(ScmapEditor.Current.map.Water.FresnelPower);
-			FresnelBias.SetValue(ScmapEditor.Current.map.Water.FresnelBias);
 
 			UnitReflection.SetValue(ScmapEditor.Current.map.Water.UnitReflection);
 			SkyReflection.SetValue(ScmapEditor.Current.map.Water.SkyReflection);
@@ -189,11 +179,7 @@ namespace EditMap
 				|| ScmapEditor.Current.map.Water.ColorLerp.y != ColorLerpYElevation.value
 				|| ScmapEditor.Current.map.Water.SurfaceColor != WaterColor.GetVectorValue()
 				|| ScmapEditor.Current.map.Water.SunColor != SunColor.GetVectorValue()
-				|| ScmapEditor.Current.map.Water.SunStrength != SunStrength.value
 				|| ScmapEditor.Current.map.Water.SunShininess != SunShininess.value
-				|| ScmapEditor.Current.map.Water.SunReflection != SunReflection.value
-				|| ScmapEditor.Current.map.Water.FresnelPower != FresnelPower.value
-				|| ScmapEditor.Current.map.Water.FresnelBias != FresnelBias.value
 				|| ScmapEditor.Current.map.Water.UnitReflection != UnitReflection.value
 				|| ScmapEditor.Current.map.Water.SkyReflection != SkyReflection.value
 				|| ScmapEditor.Current.map.Water.RefractionScale != RefractionScale.value
@@ -223,12 +209,7 @@ namespace EditMap
 			ScmapEditor.Current.map.Water.SurfaceColor = WaterColor.GetVectorValue();
 			ScmapEditor.Current.map.Water.SunColor = SunColor.GetVectorValue();
 
-			ScmapEditor.Current.map.Water.SunStrength = SunStrength.value;
 			ScmapEditor.Current.map.Water.SunShininess = SunShininess.value;
-			ScmapEditor.Current.map.Water.SunReflection = SunReflection.value;
-
-			ScmapEditor.Current.map.Water.FresnelPower = FresnelPower.value;
-			ScmapEditor.Current.map.Water.FresnelBias = FresnelBias.value;
 
 			ScmapEditor.Current.map.Water.UnitReflection = UnitReflection.value;
 			ScmapEditor.Current.map.Water.SkyReflection = SkyReflection.value;

--- a/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
@@ -29,10 +29,12 @@ namespace EditMap
 		private Vector3 SunDirection;
 
 		public UiTextField SunShininess;
-
 		public UiTextField UnitReflection;
 		public UiTextField SkyReflection;
 		public UiTextField RefractionScale;
+
+		public InputField WaterRamp;
+		public InputField Cubemap;
 
 		bool Loading = false;
 		private void OnEnable()
@@ -79,10 +81,12 @@ namespace EditMap
             SunColor.SetColorField(ScmapEditor.Current.map.Water.SunColor.x, ScmapEditor.Current.map.Water.SunColor.y, ScmapEditor.Current.map.Water.SunColor.z);
 
 			SunShininess.SetValue(ScmapEditor.Current.map.Water.SunShininess);
-
 			UnitReflection.SetValue(ScmapEditor.Current.map.Water.UnitReflection);
 			SkyReflection.SetValue(ScmapEditor.Current.map.Water.SkyReflection);
 			RefractionScale.SetValue(ScmapEditor.Current.map.Water.RefractionScale);
+
+			WaterRamp.text = ScmapEditor.Current.map.Water.TexPathWaterRamp;
+			Cubemap.text = ScmapEditor.Current.map.Water.TexPathCubemap;
 
 			WaterSettings.interactable = HasWater.isOn;
 
@@ -96,6 +100,7 @@ namespace EditMap
 
 		void UpdateScmap(bool Maps)
 		{
+			ScmapEditor.Current.SetWaterTextures();
 			ScmapEditor.Current.SetWater();
 
 			if (Maps)
@@ -206,11 +211,12 @@ namespace EditMap
 				|| ScmapEditor.Current.map.Water.UnitReflection != UnitReflection.value
 				|| ScmapEditor.Current.map.Water.SkyReflection != SkyReflection.value
 				|| ScmapEditor.Current.map.Water.RefractionScale != RefractionScale.value
+				|| ScmapEditor.Current.map.Water.TexPathWaterRamp != WaterRamp.text
+				|| ScmapEditor.Current.map.Water.TexPathCubemap != Cubemap.text
 				;
 
 			if (!AnyChanged)
 				return;
-
 
 			if (!UndoRegistered)
 			{
@@ -223,9 +229,6 @@ namespace EditMap
 			if(!Slider)
 				UndoRegistered = false;
 
-
-
-
 			ScmapEditor.Current.map.Water.ColorLerp.x = ColorLerpXElevation.value;
 			ScmapEditor.Current.map.Water.ColorLerp.y = ColorLerpYElevation.value;
 
@@ -234,10 +237,12 @@ namespace EditMap
 			ScmapEditor.Current.map.Water.SunDirection = SunDirection;
 
 			ScmapEditor.Current.map.Water.SunShininess = SunShininess.value;
-
 			ScmapEditor.Current.map.Water.UnitReflection = UnitReflection.value;
 			ScmapEditor.Current.map.Water.SkyReflection = SkyReflection.value;
 			ScmapEditor.Current.map.Water.RefractionScale = RefractionScale.value;
+			
+			ScmapEditor.Current.map.Water.TexPathWaterRamp = WaterRamp.text;
+			ScmapEditor.Current.map.Water.TexPathCubemap = Cubemap.text;
 
 			UpdateScmap(false);
 		}

--- a/Assets/Scripts/UI/UiElements/UiColor.cs
+++ b/Assets/Scripts/UI/UiElements/UiColor.cs
@@ -8,7 +8,7 @@ namespace Ozone.UI
 {
 	public class UiColor : MonoBehaviour
 	{
-		public float Clamp = 2;
+		public float Max = 2;
 		public Image ColorPreview;
 		public Image AlphaPreview;
 
@@ -29,21 +29,21 @@ namespace Ozone.UI
 		//System.Action FieldChangedAction;
 		bool Loading = false;
 
-		void ClampValues()
+		void SetSliderMax()
 		{
-			RedSlider.maxValue = Clamp;
-			GreenSlider.maxValue = Clamp;
-			BlueSlider.maxValue = Clamp;
+			RedSlider.maxValue = Max;
+			GreenSlider.maxValue = Max;
+			BlueSlider.maxValue = Max;
 			if (AlphaSlider)
-				AlphaSlider.maxValue = Clamp;
+				AlphaSlider.maxValue = Max;
 		}
 
 		Vector4 LastValue = Vector4.one;
 		void UpdateLastValue()
 		{
-			LastValue.x = RedSlider.value;
-			LastValue.y = GreenSlider.value;
-			LastValue.z = BlueSlider.value;
+			LastValue.x = LuaParser.Read.StringToFloat(Red.text);
+			LastValue.y = LuaParser.Read.StringToFloat(Green.text);
+			LastValue.z = LuaParser.Read.StringToFloat(Blue.text);
 			if (AlphaSlider)
 				LastValue.w = AlphaSlider.value;
 			else
@@ -67,7 +67,7 @@ namespace Ozone.UI
 
 		public void SetColorField(float R, float G, float B, float A = 1)
 		{
-			ClampValues();
+            SetSliderMax();
 			Loading = true;
 			//if(FieldChangedAction == null)
 			//	FieldChangedAction = ChangeAction;
@@ -76,9 +76,9 @@ namespace Ozone.UI
 			GreenSlider.value = FormatFloat(G);
 			BlueSlider.value = FormatFloat(B);
 
-			Red.text = RedSlider.value.ToString();
-			Green.text = GreenSlider.value.ToString();
-			Blue.text = BlueSlider.value.ToString();
+			Red.text = FormatFloat(R).ToString();
+			Green.text = FormatFloat(G).ToString();
+			Blue.text = FormatFloat(B).ToString();
 
 			if (AlphaSlider)
 			{
@@ -97,7 +97,7 @@ namespace Ozone.UI
 
 		public void SetColorField(Color BeginColor)
 		{
-			ClampValues();
+            SetSliderMax();
 			Loading = true;
 			//FieldChangedAction = ChangeAction;
 
@@ -105,14 +105,14 @@ namespace Ozone.UI
 			GreenSlider.value = BeginColor.g;
 			BlueSlider.value = BeginColor.b;
 
-			Red.text = RedSlider.value.ToString();
-			Green.text = GreenSlider.value.ToString();
-			Blue.text = BlueSlider.value.ToString();
+			Red.text = BeginColor.r.ToString();
+			Green.text = BeginColor.g.ToString();
+			Blue.text = BeginColor.b.ToString();
 
 			if (AlphaSlider)
 			{
 				AlphaSlider.value = BeginColor.a;
-				Alpha.text = AlphaSlider.value.ToString();
+				Alpha.text = BeginColor.a.ToString();
 			}
 
 			UpdateLastValue();
@@ -137,17 +137,13 @@ namespace Ozone.UI
 
 			Loading = true;
 
-			RedSlider.value = FormatFloat(Mathf.Clamp(LuaParser.Read.StringToFloat(Red.text), 0, Clamp));
-			GreenSlider.value = FormatFloat(Mathf.Clamp(LuaParser.Read.StringToFloat(Green.text), 0, Clamp));
-			BlueSlider.value = FormatFloat(Mathf.Clamp(LuaParser.Read.StringToFloat(Blue.text), 0, Clamp));
-
-			Red.text = RedSlider.value.ToString();
-			Green.text = GreenSlider.value.ToString();
-			Blue.text = BlueSlider.value.ToString();
+			RedSlider.value = FormatFloat(LuaParser.Read.StringToFloat(Red.text));
+			GreenSlider.value = FormatFloat(LuaParser.Read.StringToFloat(Green.text));
+			BlueSlider.value = FormatFloat(LuaParser.Read.StringToFloat(Blue.text));
 
 			if (AlphaSlider)
 			{
-				AlphaSlider.value = FormatFloat(Mathf.Clamp(LuaParser.Read.StringToFloat(Alpha.text), 0, Clamp));
+				AlphaSlider.value = FormatFloat(Mathf.Clamp(LuaParser.Read.StringToFloat(Alpha.text), 0, Max));
 				Alpha.text = AlphaSlider.value.ToString();
 			}
 
@@ -210,10 +206,10 @@ namespace Ozone.UI
 
 		void UpdateGfx()
 		{
-			ColorPreview.color = new Color(RedSlider.value / Clamp, GreenSlider.value / Clamp, BlueSlider.value / Clamp, 1);
+			ColorPreview.color = new Color(RedSlider.value / Max, GreenSlider.value / Max, BlueSlider.value / Max, 1);
 			if (AlphaPreview)
 			{
-				AlphaPreview.color = Color.Lerp(Color.black, Color.white, AlphaSlider.value / Clamp);
+				AlphaPreview.color = Color.Lerp(Color.black, Color.white, AlphaSlider.value / Max);
 			}
 		}
 	}


### PR DESCRIPTION
- Remove unused water options
- Add toggle to copy sun color and angle from light settings to get fitting sun reflections on the water
- Add toggle to switch to advanced water (this will recalculate the light settings in the background)
- Remove clamping from RGB values
- Change sun angle terminology in light settings
- Various other minor UI improvements in the water and light settings
- Fix water coloration bleeding up on shores
- Add texture paths for water ramp and skycube
![grafik](https://github.com/user-attachments/assets/e9b39dd8-9417-46d4-bec9-0009261a78a1)
![grafik](https://github.com/user-attachments/assets/f2b50ddb-86fc-4a5f-9640-7babef16e2bc)


Closes https://github.com/FAForever/FAForeverMapEditor/issues/36
Closes https://github.com/FAForever/FAForeverMapEditor/issues/37
