### PR TITLE
Shader update

### DIFF
--- a/Assets/GFX/Shaders/Deferred/Internal-DeferredShading.shader
+++ b/Assets/GFX/Shaders/Deferred/Internal-DeferredShading.shader
@@ -225,11 +225,11 @@ half4 CalculateLight (unity_v2f_deferred i)
 
 	float4 color;
 
-    if (_ShaderID == 10) {
+    if (_ShaderID == -10) {
         color.rgb = CalculateLighting(worldNormal, eyeVec, albedo, 1-alpha, atten);
-    } else if (_ShaderID == 11 || _ShaderID == 12 || _ShaderID == 0 || _ShaderID == 50) {
+    } else if (_ShaderID == -20 || _ShaderID == 20 || _ShaderID == 0 || _ShaderID == 50) {
         color.rgb = CalculateXPLighting(worldNormal, eyeVec, float4(albedo, alpha), mapShadow * atten, ambientOcclusion);
-    } else if (_ShaderID == 200 || _ShaderID == 250 || _ShaderID == 2001 || _ShaderID == 2501) {
+    } else if (_ShaderID >= 200 && _ShaderID <= 262) {
         color.rgb = PBR(wpos, eyeVec, albedo, worldNormal, roughness, mapShadow * atten, ambientOcclusion);
     } else {
         color.rgb = albedo;

--- a/Assets/GFX/Shaders/Deferred/Internal-DeferredShading.shader
+++ b/Assets/GFX/Shaders/Deferred/Internal-DeferredShading.shader
@@ -229,7 +229,7 @@ half4 CalculateLight (unity_v2f_deferred i)
         color.rgb = CalculateLighting(worldNormal, eyeVec, albedo, 1-alpha, atten);
     } else if (_ShaderID == -20 || _ShaderID == 20 || _ShaderID == 0 || _ShaderID == 50) {
         color.rgb = CalculateXPLighting(worldNormal, eyeVec, float4(albedo, alpha), mapShadow * atten, ambientOcclusion);
-    } else if (_ShaderID >= 200 && _ShaderID <= 262) {
+    } else if (_ShaderID >= 100) {
         color.rgb = PBR(wpos, eyeVec, albedo, worldNormal, roughness, mapShadow * atten, ambientOcclusion);
     } else {
         color.rgb = albedo;

--- a/Assets/GFX/Shaders/FaTerrainShader.shader
+++ b/Assets/GFX/Shaders/FaTerrainShader.shader
@@ -933,7 +933,7 @@
             void surf(Input inV, inout CustomSurfaceOutput o)
             {
                 float3 position = TerrainScale * inV.mTexWT.xyz;
-                if (_ShaderID == 10)
+                if (_ShaderID == -10)
                 {
                     float4 albedo = TerrainPS(inV);
                     o.Albedo = albedo.rgb;
@@ -944,7 +944,7 @@
 
                     o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                 }
-                else if (_ShaderID == 11)
+                else if (_ShaderID == -20)
                 {
                     float4 albedo = TerrainAlbedoXP(inV);
                     o.Albedo = albedo.rgb;
@@ -957,7 +957,7 @@
                     o.MapShadow = 1;
                     o.AmbientOcclusion = 1;
                 }
-                else if (_ShaderID == 12)
+                else if (_ShaderID == 20)
                 {
                     float4 albedo = Terrain000AlbedoPS(inV, true);
                     o.Albedo = albedo.rgb;
@@ -1052,7 +1052,83 @@
                         o.AmbientOcclusion = 1;
                     }
                 }
-                else if (_ShaderID == 2001)
+                else if (_ShaderID == 201)
+                {
+                    float4 albedo = Terrain200AlbedoPS(inV, false, 1);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200NormalsPS(inV, false).xyz);
+                    o.wNormal = normalize(normal);
+
+                    o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 251)
+                {
+                    float4 albedo = Terrain200AlbedoPS(inV, true, 1);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200NormalsPS(inV, true).xyz);
+                    o.wNormal = normalize(normal);
+
+                    o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 202)
+                {
+                    float4 albedo = Terrain200AlbedoPS(inV, false, 2);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200NormalsPS(inV, false).xyz);
+                    o.wNormal = normalize(normal);
+
+                    o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 252)
+                {
+                    float4 albedo = Terrain200AlbedoPS(inV, true, 2);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200NormalsPS(inV, true).xyz);
+                    o.wNormal = normalize(normal);
+
+                    o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 210)
                 {
                     float4 albedo = Terrain200BAlbedoPS(inV, false, 0);
                     o.Albedo = albedo.rgb;
@@ -1072,9 +1148,89 @@
                         o.AmbientOcclusion = 1;
                     }
                 }
-                else if (_ShaderID == 2501)
+                else if (_ShaderID == 260)
                 {
                     float4 albedo = Terrain200BAlbedoPS(inV, true, 0);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200BNormalsPS(inV, true).xyz);
+                    o.wNormal = normalize(normal);
+
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.WaterDepth = terrainInfo.r;
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 211)
+                {
+                    float4 albedo = Terrain200BAlbedoPS(inV, false, 1);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200BNormalsPS(inV, false).xyz);
+                    o.wNormal = normalize(normal);
+                    
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.WaterDepth = terrainInfo.r;
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 261)
+                {
+                    float4 albedo = Terrain200BAlbedoPS(inV, true, 1);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200BNormalsPS(inV, true).xyz);
+                    o.wNormal = normalize(normal);
+
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.WaterDepth = terrainInfo.r;
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 212)
+                {
+                    float4 albedo = Terrain200BAlbedoPS(inV, false, 2);
+                    o.Albedo = albedo.rgb;
+                    o.Roughness = albedo.a;
+
+                    float3 normal = TangentToWorldSpace(inV, Terrain200BNormalsPS(inV, false).xyz);
+                    o.wNormal = normalize(normal);
+                    
+                    if (Stratum7AlbedoTile < 1 && _HideStratum7 == 0) {
+                        float4 terrainInfo = tex2D(Stratum7AlbedoSampler, position.xy);
+                        o.WaterDepth = terrainInfo.r;
+                        o.MapShadow = terrainInfo.a;
+                        o.AmbientOcclusion = terrainInfo.g;
+                    } else {
+                        o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
+                        o.MapShadow = 1;
+                        o.AmbientOcclusion = 1;
+                    }
+                }
+                else if (_ShaderID == 262)
+                {
+                    float4 albedo = Terrain200BAlbedoPS(inV, true, 2);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
 

--- a/Assets/GFX/Shaders/FaTerrainShader.shader
+++ b/Assets/GFX/Shaders/FaTerrainShader.shader
@@ -84,7 +84,7 @@
 
             CGPROGRAM
 			#pragma surface surf SimpleLambert vertex:TerrainVS exclude_path:forward nometa
-            #pragma multi_compile_fog
+			#pragma multi_compile _ TTerrain TTerrainXP TTerrainXPExt Terrain000 Terrain050 Terrain200 Terrain250 Terrain201 Terrain251 Terrain202 Terrain252 Terrain200B Terrain250B Terrain201B Terrain251B Terrain202B Terrain252B
 			#pragma target 3.5
 			#include "Assets/GFX/Shaders/SimpleLambert.cginc"
 
@@ -933,8 +933,7 @@
             void surf(Input inV, inout CustomSurfaceOutput o)
             {
                 float3 position = TerrainScale * inV.mTexWT.xyz;
-                if (_ShaderID == -10)
-                {
+                #if TTerrain
                     float4 albedo = TerrainPS(inV);
                     o.Albedo = albedo.rgb;
                     o.Alpha = albedo.a; // for specularity
@@ -943,9 +942,7 @@
                     o.wNormal = normalize(normal);
 
                     o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
-                }
-                else if (_ShaderID == -20)
-                {
+                #elif TTerrainXP
                     float4 albedo = TerrainAlbedoXP(inV);
                     o.Albedo = albedo.rgb;
                     o.Alpha = albedo.a; // for specularity
@@ -956,9 +953,7 @@
                     o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                     o.MapShadow = 1;
                     o.AmbientOcclusion = 1;
-                }
-                else if (_ShaderID == 20)
-                {
+                #elif TTerrainXPExt
                     float4 albedo = Terrain000AlbedoPS(inV, true);
                     o.Albedo = albedo.rgb;
                     o.Alpha = albedo.a; // for specularity
@@ -975,9 +970,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 0)
-                {
+                #elif Terrain000
                     float4 albedo = Terrain000AlbedoPS(inV, false);
                     o.Albedo = albedo.rgb;
                     o.Alpha = albedo.a; // for specularity
@@ -994,9 +987,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 50)
-                {
+                #elif Terrain050
                     float4 albedo = Terrain000AlbedoPS(inV, true);
                     o.Albedo = albedo.rgb;
                     o.Alpha = albedo.a; // for specularity
@@ -1013,9 +1004,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 200)
-                {
+                #elif Terrain200
                     float4 albedo = Terrain200AlbedoPS(inV, false, 0);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1032,9 +1021,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 250)
-                {
+                #elif Terrain250
                     float4 albedo = Terrain200AlbedoPS(inV, true, 0);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1051,9 +1038,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 201)
-                {
+                #elif Terrain201
                     float4 albedo = Terrain200AlbedoPS(inV, false, 1);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1070,9 +1055,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 251)
-                {
+                #elif Terrain251
                     float4 albedo = Terrain200AlbedoPS(inV, true, 1);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1089,9 +1072,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 202)
-                {
+                #elif Terrain202
                     float4 albedo = Terrain200AlbedoPS(inV, false, 2);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1108,9 +1089,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 252)
-                {
+                #elif Terrain252
                     float4 albedo = Terrain200AlbedoPS(inV, true, 2);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1127,9 +1106,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 210)
-                {
+                #elif Terrain200B
                     float4 albedo = Terrain200BAlbedoPS(inV, false, 0);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1147,9 +1124,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 260)
-                {
+                #elif Terrain250B
                     float4 albedo = Terrain200BAlbedoPS(inV, true, 0);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1167,9 +1142,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 211)
-                {
+                #elif Terrain201B
                     float4 albedo = Terrain200BAlbedoPS(inV, false, 1);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1187,9 +1160,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 261)
-                {
+                #elif Terrain251B
                     float4 albedo = Terrain200BAlbedoPS(inV, true, 1);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1207,9 +1178,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 212)
-                {
+                #elif Terrain202B
                     float4 albedo = Terrain200BAlbedoPS(inV, false, 2);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1227,9 +1196,7 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else if (_ShaderID == 262)
-                {
+                #elif Terrain252B
                     float4 albedo = Terrain200BAlbedoPS(inV, true, 2);
                     o.Albedo = albedo.rgb;
                     o.Roughness = albedo.a;
@@ -1247,10 +1214,9 @@
                         o.MapShadow = 1;
                         o.AmbientOcclusion = 1;
                     }
-                }
-                else {
+                #else
                     o.Albedo = float3(1, 0, 1);
-                }
+                #endif
 
                 o.Emission = renderBrush(position.xy);
                 o.Emission += renderSlope(inV);

--- a/Assets/GFX/Shaders/FaTerrainShader.shader
+++ b/Assets/GFX/Shaders/FaTerrainShader.shader
@@ -35,9 +35,11 @@
         UtilitySamplerB ("masks of stratum layers 4 - 7", 2D) = "black" {}
         UtilitySamplerC ("water properties", 2D) = "black" {}  // not set?
 
-    	LowerAlbedoSampler ("Layer Lower (R)", 2D) = "white" {}
-	    LowerNormalSampler ("Normal Lower (R)", 2D) = "bump" {}
-    	UpperAlbedoSampler ("Layer Upper (R)", 2D) = "white" {}
+    	LowerAlbedoSampler ("Lower Albedo", 2D) = "white" {}
+	    LowerNormalSampler ("Lower Normal", 2D) = "bump" {}
+        Stratum7AlbedoSampler ("Stratum 7 Albedo", 2D) = "white" {}
+	    Stratum7NormalSampler ("Stratum 7 Normal", 2D) = "bump" {}
+    	UpperAlbedoSampler ("Upper Albedo", 2D) = "white" {}
 
         _StratumAlbedoArray ("Albedo array", 2DArray) = "" {}
 	    _StratumNormalArray ("Normal array", 2DArray) = "" {}
@@ -158,6 +160,8 @@
             sampler2D LowerAlbedoSampler;
             sampler2D UpperAlbedoSampler;
             sampler2D LowerNormalSampler;
+			sampler2D Stratum7AlbedoSampler;
+			sampler2D Stratum7NormalSampler;
        
 			UNITY_DECLARE_TEX2DARRAY(_StratumAlbedoArray);
 			UNITY_DECLARE_TEX2DARRAY(_StratumNormalArray);
@@ -196,7 +200,7 @@
                 float3 worldNormal;
                 if (Stratum7NormalTile < 1.0 && _HideStratum7 == 0) {
                     float3 normal;
-                    normal.xz = StratumNormalSampler(7, TerrainScale * v.mTexWT.xy).ag * 2 - 1;
+                    normal.xz = tex2D(Stratum7NormalSampler, TerrainScale * v.mTexWT.xy).ag * 2 - 1;
                     normal.z = normal.z * -1;
                     // reconstruct y component
                     normal.y = sqrt(1 - dot(normal.xz, normal.xz));
@@ -320,7 +324,7 @@
                 float4 stratum4Normal = normalize(StratumNormalSampler(4,pixel.mTexWT*TerrainScale*Stratum4NormalTile)*2-1);
                 float4 stratum5Normal = normalize(StratumNormalSampler(5,pixel.mTexWT*TerrainScale*Stratum5NormalTile)*2-1);
                 float4 stratum6Normal = normalize(StratumNormalSampler(6,pixel.mTexWT*TerrainScale*Stratum6NormalTile)*2-1);
-                float4 stratum7Normal = normalize(StratumNormalSampler(7,pixel.mTexWT*TerrainScale*Stratum7NormalTile)*2-1);
+                float4 stratum7Normal = normalize(tex2D(Stratum7NormalSampler,pixel.mTexWT*TerrainScale*Stratum7NormalTile)*2-1);
 
                 float4 normal = lowerNormal;
                 if(_HideStratum0 == 0)
@@ -359,7 +363,7 @@
                 float4 stratum4Albedo = StratumAlbedoSampler(4,position*Stratum4AlbedoTile);
                 float4 stratum5Albedo = StratumAlbedoSampler(5,position*Stratum5AlbedoTile);
                 float4 stratum6Albedo = StratumAlbedoSampler(6,position*Stratum6AlbedoTile);
-                float4 stratum7Albedo = StratumAlbedoSampler(7,position*Stratum7AlbedoTile);
+                float4 stratum7Albedo = tex2D(Stratum7AlbedoSampler,position*Stratum7AlbedoTile);
                 float4 upperAlbedo = tex2D(UpperAlbedoSampler,position*UpperAlbedoTile);
 
                 float4 albedo = lowerAlbedo;
@@ -719,7 +723,7 @@
                 float stratum5Height = sampleHeight(position.xy, Stratum5AlbedoTile.xx, Stratum5NormalTile.xx, float2(0.0, 0.5), false);
                 float stratum6Height = sampleHeight(rotated_pos, Stratum6AlbedoTile.xx, Stratum6NormalTile.xx, float2(0.5, 0.5), false);
 
-                float2 terrainNormal = StratumNormalSampler(7, position.xy).ag * 2 - 1;
+                float2 terrainNormal = tex2D(Stratum7NormalSampler, position.xy).ag * 2 - 1;
                 float2 blendWeights = pow(abs(terrainNormal), 3);
                 blendWeights = blendWeights / (blendWeights.x + blendWeights.y);
 
@@ -782,7 +786,7 @@
                 float stratum5Height = sampleHeight(position.xy, Stratum5AlbedoTile.xx, Stratum5NormalTile.xx, float2(0.0, 0.5), false);
                 float stratum6Height = sampleHeight(rotated_pos, Stratum6AlbedoTile.xx, Stratum6NormalTile.xx, float2(0.5, 0.5), false);
 
-                float2 terrainNormal = StratumNormalSampler(7, position.xy).ag * 2 - 1;
+                float2 terrainNormal = tex2D(Stratum7NormalSampler, position.xy).ag * 2 - 1;
                 float2 blendWeights = pow(abs(terrainNormal), 3);
                 blendWeights = blendWeights / (blendWeights.x + blendWeights.y);
 
@@ -962,8 +966,8 @@
                     o.wNormal = normalize(normal);
 
                     if (_HideStratum7 == 0) {
-                        o.WaterDepth = StratumAlbedoSampler(7, position.xy).a;
-                        o.MapShadow = StratumAlbedoSampler(7, position.xy).g;
+                        o.WaterDepth = tex2D(Stratum7AlbedoSampler, position.xy).a;
+                        o.MapShadow = tex2D(Stratum7AlbedoSampler, position.xy).g;
                     } else {
                         o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                         o.MapShadow = 1;
@@ -979,8 +983,8 @@
                     o.wNormal = normalize(normal);
 
                     if (_HideStratum7 == 0) {
-                        o.WaterDepth = StratumAlbedoSampler(7, position.xy).a;
-                        o.MapShadow = StratumAlbedoSampler(7, position.xy).g;
+                        o.WaterDepth = tex2D(Stratum7AlbedoSampler, position.xy).a;
+                        o.MapShadow = tex2D(Stratum7AlbedoSampler, position.xy).g;
                     } else {
                         o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                         o.MapShadow = 1;
@@ -996,8 +1000,8 @@
                     o.wNormal = normalize(normal);
 
                     if (_HideStratum7 == 0) {
-                        o.WaterDepth = StratumAlbedoSampler(7, position.xy).a;
-                        o.MapShadow = StratumAlbedoSampler(7, position.xy).g;
+                        o.WaterDepth = tex2D(Stratum7AlbedoSampler, position.xy).a;
+                        o.MapShadow = tex2D(Stratum7AlbedoSampler, position.xy).g;
                     } else {
                         o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                         o.MapShadow = 1;
@@ -1013,8 +1017,8 @@
                     o.wNormal = normalize(normal);
 
                     if (_HideStratum7 == 0) {
-                        o.WaterDepth = StratumAlbedoSampler(7, position.xy).a;
-                        o.MapShadow = StratumAlbedoSampler(7, position.xy).g;
+                        o.WaterDepth = tex2D(Stratum7AlbedoSampler, position.xy).a;
+                        o.MapShadow = tex2D(Stratum7AlbedoSampler, position.xy).g;
                     } else {
                         o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                         o.MapShadow = 1;
@@ -1030,8 +1034,8 @@
                     o.wNormal = normalize(normal);
 
                     if (_HideStratum7 == 0) {
-                        o.WaterDepth = StratumAlbedoSampler(7, position.xy).a;
-                        o.MapShadow = StratumAlbedoSampler(7, position.xy).g;
+                        o.WaterDepth = tex2D(Stratum7AlbedoSampler, position.xy).a;
+                        o.MapShadow = tex2D(Stratum7AlbedoSampler, position.xy).g;
                     } else {
                         o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                         o.MapShadow = 1;
@@ -1047,8 +1051,8 @@
                     o.wNormal = normalize(normal);
 
                     if (_HideStratum7 == 0) {
-                        o.WaterDepth = StratumAlbedoSampler(7, position.xy).a;
-                        o.MapShadow = StratumAlbedoSampler(7, position.xy).g;
+                        o.WaterDepth = tex2D(Stratum7AlbedoSampler, position.xy).a;
+                        o.MapShadow = tex2D(Stratum7AlbedoSampler, position.xy).g;
                     } else {
                         o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                         o.MapShadow = 1;
@@ -1064,8 +1068,8 @@
                     o.wNormal = normalize(normal);
 
                     if (_HideStratum7 == 0) {
-                        o.WaterDepth = StratumAlbedoSampler(7, position.xy).a;
-                        o.MapShadow = StratumAlbedoSampler(7, position.xy).g;
+                        o.WaterDepth = tex2D(Stratum7AlbedoSampler, position.xy).a;
+                        o.MapShadow = tex2D(Stratum7AlbedoSampler, position.xy).g;
                     } else {
                         o.WaterDepth = tex2D(UtilitySamplerC, position.xy).g;
                         o.MapShadow = 1;

--- a/Assets/GFX/Shaders/FaTerrainShader.shader
+++ b/Assets/GFX/Shaders/FaTerrainShader.shader
@@ -598,7 +598,7 @@
                     mask1 = saturate(mask1 * 2 - 1);
                 }
 
-                float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,  position.xy * LowerAlbedoTile.xx).rgb * 2 - 1);
+                float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,  position.xy * LowerNormalTile.xx).rgb * 2 - 1);
                 float3 stratum0Normal = normalize(StratumNormalSampler(0, rotated_pos * Stratum0AlbedoTile.xx).rgb * 2 - 1);
                 float3 stratum1Normal = normalize(StratumNormalSampler(1, position.xy * Stratum1AlbedoTile.xx).rgb * 2 - 1);
                 float3 stratum2Normal = normalize(StratumNormalSampler(2, rotated_pos * Stratum2AlbedoTile.xx).rgb * 2 - 1);
@@ -717,7 +717,7 @@
                     mask1 = saturate(mask1 * 2 - 1);
                 }
 
-                float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,  position.xy * LowerAlbedoTile.xx).rgb * 2 - 1);
+                float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,  position.xy * LowerNormalTile.xx).rgb * 2 - 1);
                 float3 stratum0Normal = normalize(StratumNormalSampler(0, rotated_pos * Stratum0AlbedoTile.xx).rgb * 2 - 1);
                 float3 stratum1Normal = normalize(StratumNormalSampler(1, position.xy * Stratum1AlbedoTile.xx).rgb * 2 - 1);
                 float3 stratum4Normal = normalize(StratumNormalSampler(4, rotated_pos * Stratum4AlbedoTile.xx).rgb * 2 - 1);

--- a/Assets/GFX/Shaders/FaWaterShader.shader
+++ b/Assets/GFX/Shaders/FaWaterShader.shader
@@ -142,7 +142,7 @@
 		float3 calculateSunReflection(float3 R, float3 v, float3 n)
 		{
 			// for unknown reasons the game seems to mess with the SunColor, so we also need to correct
-			if (_ShaderID == 10) {
+			if (_ShaderID == -10) {
 				SunColor *= 2;
 			} else {
 				SunColor *= 0.75;

--- a/Assets/GFX/Shaders/SimpleLambert.cginc
+++ b/Assets/GFX/Shaders/SimpleLambert.cginc
@@ -13,6 +13,7 @@ struct CustomSurfaceOutput
     half MapShadow; // manual terrain shadow that is defined by input texture
     half Roughness;
     half Alpha;
+	half AmbientOcclusion;
     
     // this only exists to make the surface shader compile and is unused
     float3 Normal;
@@ -50,7 +51,7 @@ inline half4 LightingSimpleLambert_Deferred(CustomSurfaceOutput s, UnityGI gi, o
 {
     outGBuffer0 = half4(s.Albedo, s.Alpha);
 
-    outGBuffer1 = half4(s.MapShadow, s.WaterDepth, s.Roughness, 0);
+    outGBuffer1 = half4(s.MapShadow, s.WaterDepth, s.Roughness, s.AmbientOcclusion);
 
     outGBuffer2 = half4(s.wNormal * 0.5f + 0.5f, 0);
 

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -1111,6 +1111,42 @@ public partial class ScmapEditor : MonoBehaviour
 			case "Terrain050":
 				shaderId = 50;
 				break;
+			case "Terrain100":
+				shaderId = 100;
+				break;
+			case "Terrain150":
+				shaderId = 150;
+				break;
+			case "Terrain101":
+				shaderId = 101;
+				break;
+			case "Terrain151":
+				shaderId = 151;
+				break;
+			case "Terrain102":
+				shaderId = 102;
+				break;
+			case "Terrain152":
+				shaderId = 152;
+				break;
+			case "Terrain100B":
+				shaderId = 110;
+				break;
+			case "Terrain150B":
+				shaderId = 160;
+				break;
+			case "Terrain101B":
+				shaderId = 111;
+				break;
+			case "Terrain151B":
+				shaderId = 161;
+				break;
+			case "Terrain102B":
+				shaderId = 112;
+				break;
+			case "Terrain152B":
+				shaderId = 162;
+				break;
 			case "Terrain200":
 				shaderId = 200;
 				break;
@@ -1158,7 +1194,7 @@ public partial class ScmapEditor : MonoBehaviour
             Textures[8].NormalScale = 10000;  // Use terrain normal texture
             MapLuaParser.Current.EditMenu.TexturesMenu.ShaderTools.interactable = true;
             MapLuaParser.Current.EditMenu.TexturesMenu.ShaderTools.alpha = 1;
-            if (shaderId >= 200)
+            if (shaderId >= 100)
             {
                 Textures[9].AlbedoScale = 10000;  // Use PBR rendering on decals
             }
@@ -1174,6 +1210,11 @@ public partial class ScmapEditor : MonoBehaviour
 			MapLuaParser.Current.EditMenu.LightingMenu.Specular.gameObject.SetActive(false);
 			MapLuaParser.Current.EditMenu.LightingMenu.SpecularRed.gameObject.SetActive(true);
 			MapLuaParser.Current.EditMenu.LightingMenu.SpecularRed.SetTitle("Texture Blending Blurriness");
+		}
+		else if (shaderId >= 100)
+		{
+			MapLuaParser.Current.EditMenu.LightingMenu.Specular.gameObject.SetActive(false);
+			MapLuaParser.Current.EditMenu.LightingMenu.SpecularRed.gameObject.SetActive(false);
 		}
 		else if (shaderId == -10)  //TTerrain
 		{

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -1087,56 +1087,72 @@ public partial class ScmapEditor : MonoBehaviour
 
 	public void ToogleShader()
 	{
+		int shaderId;
 		switch (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text)
 		{
 			case "TTerrain":
-				Shader.SetGlobalInt("_ShaderID", 10);
+				shaderId = -10;
 				break;
 			case "TTerrainXP":
-				Shader.SetGlobalInt("_ShaderID", 11);
+				shaderId = -20;
 				break;
 			case "TTerrainXPExt":
-				Shader.SetGlobalInt("_ShaderID", 12);
+				shaderId = 20;
 				break;
 			case "Terrain000":
-				Shader.SetGlobalInt("_ShaderID", 0);
+				shaderId = 0;
 				break;
 			case "Terrain050":
-				Shader.SetGlobalInt("_ShaderID", 50);
+				shaderId = 50;
 				break;
 			case "Terrain200":
-				Shader.SetGlobalInt("_ShaderID", 200);
+				shaderId = 200;
 				break;
 			case "Terrain250":
-				Shader.SetGlobalInt("_ShaderID", 250);
+				shaderId = 250;
+				break;
+			case "Terrain201":
+				shaderId = 201;
+				break;
+			case "Terrain251":
+				shaderId = 251;
+				break;
+			case "Terrain202":
+				shaderId = 202;
+				break;
+			case "Terrain252":
+				shaderId = 252;
 				break;
 			case "Terrain200B":
-				Shader.SetGlobalInt("_ShaderID", 2001);
+				shaderId = 210;
 				break;
 			case "Terrain250B":
-				Shader.SetGlobalInt("_ShaderID", 2501);
+				shaderId = 260;
+				break;
+			case "Terrain201B":
+				shaderId = 211;
+				break;
+			case "Terrain251B":
+				shaderId = 261;
+				break;
+			case "Terrain202B":
+				shaderId = 212;
+				break;
+			case "Terrain252B":
+				shaderId = 262;
 				break;
 			default:
-				Shader.SetGlobalInt("_ShaderID", -1);
+				shaderId = -1;
 				break;
 		}
 
-		if (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "TTerrainXPExt" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain000" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain050" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200B" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250B")
+		if (shaderId >= 0)
         {
-            Textures[8].AlbedoScale = 10000;  // Use map shadow on decals
+            Textures[8].AlbedoScale = 10000;  // Use terrain info texture
             Textures[8].NormalScale = 10000;  // Use terrain normal texture
             MapLuaParser.Current.EditMenu.TexturesMenu.ShaderTools.interactable = true;
             MapLuaParser.Current.EditMenu.TexturesMenu.ShaderTools.alpha = 1;
-            if (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200" ||
-                MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250" ||
-                MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200B" ||
-                MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250B")
+            if (shaderId >= 200)
             {
                 Textures[9].AlbedoScale = 10000;  // Use PBR rendering on decals
             }
@@ -1147,16 +1163,13 @@ public partial class ScmapEditor : MonoBehaviour
 			MapLuaParser.Current.EditMenu.TexturesMenu.ShaderTools.alpha = 0.7f;
 		}
 		
-		if (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200B" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250B")
+		if (shaderId >= 200)
 		{
 			MapLuaParser.Current.EditMenu.LightingMenu.Specular.gameObject.SetActive(false);
 			MapLuaParser.Current.EditMenu.LightingMenu.SpecularRed.gameObject.SetActive(true);
 			MapLuaParser.Current.EditMenu.LightingMenu.SpecularRed.SetTitle("Texture Blending Blurriness");
 		}
-		else if (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "TTerrain")
+		else if (shaderId == -10)  //TTerrain
 		{
 			MapLuaParser.Current.EditMenu.LightingMenu.Specular.gameObject.SetActive(false);
 			MapLuaParser.Current.EditMenu.LightingMenu.SpecularRed.gameObject.SetActive(true);
@@ -1167,6 +1180,8 @@ public partial class ScmapEditor : MonoBehaviour
 			MapLuaParser.Current.EditMenu.LightingMenu.Specular.gameObject.SetActive(true);
 			MapLuaParser.Current.EditMenu.LightingMenu.SpecularRed.gameObject.SetActive(false);
 		}
+		
+		Shader.SetGlobalInt("_ShaderID", shaderId);
 	}
 #endregion
 }

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -1087,6 +1087,12 @@ public partial class ScmapEditor : MonoBehaviour
 
 	public void ToogleShader()
 	{
+		foreach (var localKeyword in TerrainMaterial.shader.keywordSpace.keywords)
+		{
+			TerrainMaterial.DisableKeyword(localKeyword);
+		}
+		TerrainMaterial.EnableKeyword(MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text);
+		
 		int shaderId;
 		switch (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text)
 		{

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -451,14 +451,30 @@ public partial class ScmapEditor : MonoBehaviour
 #region Textures
 	public void SetTextures(int Layer = -1)
 	{
-
 		if (Layer < 0)
 		{
 			TerrainMaterial.SetTexture("UtilitySamplerA", map.TexturemapTex);
 			if (Textures[5].Albedo || Textures[6].Albedo || Textures[7].Albedo || Textures[8].Albedo)
 				TerrainMaterial.SetTexture("UtilitySamplerB", map.TexturemapTex2);
-		}
+			
+			TerrainMaterial.SetFloat("Stratum0AlbedoTile", map.Width / Textures[1].AlbedoScale);
+            TerrainMaterial.SetFloat("Stratum1AlbedoTile", map.Width / Textures[2].AlbedoScale);
+            TerrainMaterial.SetFloat("Stratum2AlbedoTile", map.Width / Textures[3].AlbedoScale);
+            TerrainMaterial.SetFloat("Stratum3AlbedoTile", map.Width / Textures[4].AlbedoScale);
+            TerrainMaterial.SetFloat("Stratum4AlbedoTile", map.Width / Textures[5].AlbedoScale);
+            TerrainMaterial.SetFloat("Stratum5AlbedoTile", map.Width / Textures[6].AlbedoScale);
+            TerrainMaterial.SetFloat("Stratum6AlbedoTile", map.Width / Textures[7].AlbedoScale);
 
+            TerrainMaterial.SetFloat("Stratum0NormalTile", map.Width / Textures[1].NormalScale);
+            TerrainMaterial.SetFloat("Stratum1NormalTile", map.Width / Textures[2].NormalScale);
+            TerrainMaterial.SetFloat("Stratum2NormalTile", map.Width / Textures[3].NormalScale);
+            TerrainMaterial.SetFloat("Stratum3NormalTile", map.Width / Textures[4].NormalScale);
+            TerrainMaterial.SetFloat("Stratum4NormalTile", map.Width / Textures[5].NormalScale);
+            TerrainMaterial.SetFloat("Stratum5NormalTile", map.Width / Textures[6].NormalScale);
+            TerrainMaterial.SetFloat("Stratum6NormalTile", map.Width / Textures[7].NormalScale);
+            
+            GenerateArrays();
+		}
 
 		if (Layer <= 0)
 		{
@@ -468,31 +484,20 @@ public partial class ScmapEditor : MonoBehaviour
 			TerrainMaterial.SetTexture("LowerNormalSampler", Textures[0].Normal);
 		}
 
-		if (Layer > 0 && Layer < 9)
+		if (Layer >= 1 && Layer <= 7)
 		{
 			string IdStrig = (Layer - 1).ToString();
 			TerrainMaterial.SetFloat("Stratum" + IdStrig + "AlbedoTile", map.Width / Textures[Layer].AlbedoScale);
 			TerrainMaterial.SetFloat("Stratum" + IdStrig + "NormalTile", map.Width / Textures[Layer].NormalScale);
+			GenerateArrays();
 		}
-		else
+		
+		if (Layer == 8 || Layer < 0)
 		{
-			TerrainMaterial.SetFloat("Stratum0AlbedoTile", map.Width / Textures[1].AlbedoScale);
-			TerrainMaterial.SetFloat("Stratum1AlbedoTile", map.Width / Textures[2].AlbedoScale);
-			TerrainMaterial.SetFloat("Stratum2AlbedoTile", map.Width / Textures[3].AlbedoScale);
-			TerrainMaterial.SetFloat("Stratum3AlbedoTile", map.Width / Textures[4].AlbedoScale);
-			TerrainMaterial.SetFloat("Stratum4AlbedoTile", map.Width / Textures[5].AlbedoScale);
-			TerrainMaterial.SetFloat("Stratum5AlbedoTile", map.Width / Textures[6].AlbedoScale);
-			TerrainMaterial.SetFloat("Stratum6AlbedoTile", map.Width / Textures[7].AlbedoScale);
 			TerrainMaterial.SetFloat("Stratum7AlbedoTile", map.Width / Textures[8].AlbedoScale);
-
-			TerrainMaterial.SetFloat("Stratum0NormalTile", map.Width / Textures[1].NormalScale);
-			TerrainMaterial.SetFloat("Stratum1NormalTile", map.Width / Textures[2].NormalScale);
-			TerrainMaterial.SetFloat("Stratum2NormalTile", map.Width / Textures[3].NormalScale);
-			TerrainMaterial.SetFloat("Stratum3NormalTile", map.Width / Textures[4].NormalScale);
-			TerrainMaterial.SetFloat("Stratum4NormalTile", map.Width / Textures[5].NormalScale);
-			TerrainMaterial.SetFloat("Stratum5NormalTile", map.Width / Textures[6].NormalScale);
-			TerrainMaterial.SetFloat("Stratum6NormalTile", map.Width / Textures[7].NormalScale);
 			TerrainMaterial.SetFloat("Stratum7NormalTile", map.Width / Textures[8].NormalScale);
+			TerrainMaterial.SetTexture("Stratum7AlbedoSampler", Textures[8].Albedo);
+			TerrainMaterial.SetTexture("Stratum7NormalSampler", Textures[8].Normal);
 		}
 
 		if (Layer == 9 || Layer < 0)
@@ -500,19 +505,16 @@ public partial class ScmapEditor : MonoBehaviour
 			TerrainMaterial.SetFloat("UpperAlbedoTile", map.Width / Textures[9].AlbedoScale);
 			TerrainMaterial.SetTexture("UpperAlbedoSampler", Textures[9].Albedo);
 		}
-
-		if(Layer != 9 && Layer != 0)
-		{
-			GenerateArrays();
-		}
 	}
 
+	// We need an array texture to reduce the amount of samplers in the shader,
+	// but we exclude stratum 7 as it might hold very large textures.
 	void GenerateArrays()
 	{
 		int AlbedoSize = 256;
 		int MipMapCount = 10;
 
-		for (int i = 0; i < 8; i++)
+		for (int i = 0; i < 7; i++)
 		{
 			if (Textures[i + 1].Albedo.width > AlbedoSize)
 			{
@@ -526,9 +528,9 @@ public partial class ScmapEditor : MonoBehaviour
 			}
 		}
 
-		Texture2DArray AlbedoArray = new Texture2DArray(AlbedoSize, AlbedoSize, 8, TextureFormat.RGBA32, true);
+		Texture2DArray AlbedoArray = new Texture2DArray(AlbedoSize, AlbedoSize, 7, TextureFormat.RGBA32, true);
 
-		for (int i = 0; i < 8; i++)
+		for (int i = 0; i < 7; i++)
 		{
 			if(!Textures[i + 1].Albedo.isReadable)
 			{
@@ -568,7 +570,7 @@ public partial class ScmapEditor : MonoBehaviour
 
 		AlbedoSize = 256;
 
-		for (int i = 0; i < 8; i++)
+		for (int i = 0; i < 7; i++)
 		{
 			if (Textures[i + 1].Normal == null)
 				continue;
@@ -582,9 +584,9 @@ public partial class ScmapEditor : MonoBehaviour
 			}
 		}
 
-		Texture2DArray NormalArray = new Texture2DArray(AlbedoSize, AlbedoSize, 8, TextureFormat.RGBA32, true);
+		Texture2DArray NormalArray = new Texture2DArray(AlbedoSize, AlbedoSize, 7, TextureFormat.RGBA32, true);
 
-		for (int i = 0; i < 8; i++)
+		for (int i = 0; i < 7; i++)
 		{
 			if (!Textures[i + 1].Normal.isReadable)
 			{

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -1106,7 +1106,6 @@ public partial class ScmapEditor : MonoBehaviour
 				Shader.SetGlobalInt("_ShaderID", 200);
 				break;
 			case "Terrain250":
-			case "Terrain301":
 				Shader.SetGlobalInt("_ShaderID", 250);
 				break;
 			case "Terrain200B":
@@ -1125,14 +1124,20 @@ public partial class ScmapEditor : MonoBehaviour
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain050" ||
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200" ||
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain301" ||
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200B" ||
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250B")
         {
-            Textures[9].AlbedoScale = 10000;
-            Textures[8].NormalScale = 10000;
+            Textures[8].AlbedoScale = 10000;  // Use map shadow on decals
+            Textures[8].NormalScale = 10000;  // Use terrain normal texture
             MapLuaParser.Current.EditMenu.TexturesMenu.ShaderTools.interactable = true;
             MapLuaParser.Current.EditMenu.TexturesMenu.ShaderTools.alpha = 1;
+            if (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200" ||
+                MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250" ||
+                MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200B" ||
+                MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250B")
+            {
+                Textures[9].AlbedoScale = 10000;  // Use PBR rendering on decals
+            }
         }
 		else
 		{
@@ -1142,7 +1147,6 @@ public partial class ScmapEditor : MonoBehaviour
 		
 		if (MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200" ||
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250" ||
-		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain301" ||
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain200B" ||
 		    MapLuaParser.Current.EditMenu.MapInfoMenu.ShaderName.text == "Terrain250B")
 		{

--- a/Assets/Scripts/UI/Tools/Textures/StratumInfo.cs
+++ b/Assets/Scripts/UI/Tools/Textures/StratumInfo.cs
@@ -422,8 +422,7 @@ namespace EditMap
                 }
 				else if (Selected == 8)
 				{
-                    Stratum_Albedo_Input.SetTitle("Macrotexture Scale");
-                    Stratum_Albedo_Input.gameObject.SetActive(true);
+                    Stratum_Albedo_Input.gameObject.SetActive(false);
                     Stratum_Normal_Input.gameObject.SetActive(false);
                 }
 				else
@@ -1175,11 +1174,11 @@ namespace EditMap
 	        Undo.RegisterUndo(new UndoHistory.HistoryStratumChange(), new UndoHistory.HistoryStratumChange.StratumChangeHistoryParameter(9));
                 
 	        string texturePath = MapLuaParser.RelativeLoadedMapFolderPath + "env/layers/mapwide.dds";
-	        ScmapEditor.Current.Textures[9].Albedo = GetGamedataFile.LoadTexture2D(texturePath);;
-	        ScmapEditor.Current.Textures[9].AlbedoPath = texturePath;
-	        ScmapEditor.Current.SetTextures(9);
-	        ReloadStratums();
-	        SelectStratum(9);
+	        ScmapEditor.Current.Textures[8].Normal = GetGamedataFile.LoadTexture2D(texturePath);
+            ScmapEditor.Current.Textures[8].NormalPath = texturePath;
+            ScmapEditor.Current.SetTextures(8);
+            ReloadStratums();
+            SelectStratum(8);
         }
         
         public void GenerateHeightRoughnessTexture()
@@ -1197,11 +1196,11 @@ namespace EditMap
 	        Undo.RegisterUndo(new UndoHistory.HistoryStratumChange(), new UndoHistory.HistoryStratumChange.StratumChangeHistoryParameter(9));
                 
 	        string texturePath = MapLuaParser.RelativeLoadedMapFolderPath + "env/layers/heightroughness.dds";
-	        ScmapEditor.Current.Textures[8].Normal = GetGamedataFile.LoadTexture2D(texturePath);;
-	        ScmapEditor.Current.Textures[8].NormalPath = texturePath;
-	        ScmapEditor.Current.SetTextures(8);
-	        ReloadStratums();
-	        SelectStratum(8);
+	        ScmapEditor.Current.Textures[9].Albedo = GetGamedataFile.LoadTexture2D(texturePath);
+            ScmapEditor.Current.Textures[9].AlbedoPath = texturePath;
+            ScmapEditor.Current.SetTextures(9);
+            ReloadStratums();
+            SelectStratum(9);
         }
         
         public void ResetRoughnessMask()

--- a/Assets/Scripts/UI/Tools/Textures/StratumInfo.cs
+++ b/Assets/Scripts/UI/Tools/Textures/StratumInfo.cs
@@ -411,10 +411,7 @@ namespace EditMap
 				Stratum_Normal_Input.gameObject.SetActive(false);
 			}
 
-			if (Shader.GetGlobalInt("_ShaderID") == 200 ||
-			    Shader.GetGlobalInt("_ShaderID") == 250 ||
-			    Shader.GetGlobalInt("_ShaderID") == 2001 ||
-			    Shader.GetGlobalInt("_ShaderID") == 2501)
+			if (Shader.GetGlobalInt("_ShaderID") >= 200)
 			{
 				if (Selected == 9)
 				{


### PR DESCRIPTION
- Accomodate to the changes from https://github.com/FAForever/fa/pull/6683
- Add previously missing shaders
- Exclude layer 7 from the array texture. Especially the terrain normal texture can be very big. All textures in an array texture have to have the same size, so all other layers would have to be upscaled to that dimension which simply fails or makes the editor crash.