### PR TITLE
More bugfixes

### DIFF
--- a/Assets/GFX/Shaders/FaTerrainShader.shader
+++ b/Assets/GFX/Shaders/FaTerrainShader.shader
@@ -203,7 +203,7 @@
                     normal.xz = tex2D(Stratum7NormalSampler, TerrainScale * v.mTexWT.xy).ag * 2 - 1;
                     normal.z = normal.z * -1;
                     // reconstruct y component
-                    normal.y = sqrt(1 - dot(normal.xz, normal.xz));
+                    normal.y = sqrt(abs(1 - dot(normal.xz, normal.xz)));
 
                     // when we read the terrain normals from a texture, we need to build our own TBN matrix
                     float3 tangent = cross(normal, float3(0, 0, 1));

--- a/Assets/GFX/Shaders/FaWaterShader.shader
+++ b/Assets/GFX/Shaders/FaWaterShader.shader
@@ -4,6 +4,7 @@
 		SunColor  ("Sun Color", Color) = (0, 0, 0, 0)
 		waterLerp ("water Lerp", Vector) = (0, 0, 0, 0)
 		SunDirection  ("Sun Direction", Vector) = (0, 0, 0, 0)
+		SunReflectionAmount ("Sun Reflection Amount", Float) = 0
 		SunShininess ("SunShininess", Float) = 0
 		skyreflectionAmount ("sky reflection Amount", Float) = 0
 		refractionScale ("refraction Scale", Float) = 0
@@ -56,6 +57,7 @@
 		float2 normal3Movement;
 		float2 normal4Movement;
 
+		float SunReflectionAmount;
 		float SunShininess;
 	    float3 SunDirection;
 		float4 SunColor;
@@ -141,12 +143,8 @@
 
 		float3 calculateSunReflection(float3 R, float3 v, float3 n)
 		{
-			// for unknown reasons the game seems to mess with the SunColor, so we also need to correct
-			if (_ShaderID == -10) {
-				SunColor *= 2;
-			} else {
-				SunColor *= 0.75;
-			}
+			// the game alters the SunColor internally
+			SunColor *= SunReflectionAmount;
 
 			float3 color;
 			// Legacy fallback for the old behaviour, so we don't change all maps accidentally.

--- a/Assets/GFX/Terrain/Terrain.mat
+++ b/Assets/GFX/Terrain/Terrain.mat
@@ -32,6 +32,14 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - Stratum7AlbedoSampler:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - Stratum7NormalSampler:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - UpperAlbedoSampler:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/Assets/GFX/Terrain/Water.mat
+++ b/Assets/GFX/Terrain/Water.mat
@@ -109,6 +109,8 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - SunReflection: 0
+    - SunReflectionAmount: 2.02
     - SunShininess: 78.9
     - _BumpScale: 1
     - _Cutoff: 0.5

--- a/Assets/Scripts/HazardX SCMAP Code/WaterShader.cs
+++ b/Assets/Scripts/HazardX SCMAP Code/WaterShader.cs
@@ -66,7 +66,7 @@ public class WaterShader
         SunStrength = 0f;
         SunDirection = new Vector3(0.09954818f, -0.9626309f, 0.2518569f);
         SunColor = new Vector3(0.52f, 0.47f, 0.35f);
-        SunReflection = 0f;
+        SunReflection = 1f;
         SunGlow = 0f;
 
         TexPathCubemap = "/textures/environment/skycube_evergreen01a.dds";

--- a/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile.cs
@@ -216,7 +216,7 @@ public partial struct GetGamedataFile
 			}
 			else if (ScmapEditor.Current.Textures[Id].Albedo.width > 4 && ScmapEditor.Current.Textures[Id].Albedo.height > 4 && ScmapEditor.Current.Textures[Id].Albedo.mipmapCount <= 1)
 			{
-				//Debug.Log("Force mipmaps: " + LocalPath + " has " + ScmapEditor.Current.Textures[Id].Albedo.mipmapCount + " mipmaps");
+				Debug.Log("Force mipmaps: " + LocalPath + " has " + ScmapEditor.Current.Textures[Id].Albedo.mipmapCount + " mipmaps");
 				ScmapEditor.Current.Textures[Id].Albedo = ConvertWithMipmaps(ScmapEditor.Current.Textures[Id].Albedo);
 			}
 		}

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -548,10 +548,6 @@ public partial class ScmapEditor : MonoBehaviour
 				Textures[i + 1].Albedo = TextureScale.Bilinear(Textures[i + 1].Albedo, AlbedoSize, AlbedoSize);
 			}
 
-
-			//if (i == 0)
-			//	MipMapCount = Textures[i + 1].Albedo.mipmapCount;
-
 			if (MipMapCount != Textures[i + 1].Albedo.mipmapCount)
 				Debug.LogWarning("Wrong mipmap Count: " + Textures[i + 1].Albedo.mipmapCount + " for texture" + Textures[i + 1].AlbedoPath);
 			for (int m = 0; m < MipMapCount; m++)

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -390,6 +390,7 @@ public partial class ScmapEditor : MonoBehaviour
 		WaterMaterial.SetVector("SunColor", map.Water.SunColor);
         WaterMaterial.SetVector("waterLerp", map.Water.ColorLerp);
 		WaterMaterial.SetVector("SunDirection", map.Water.SunDirection);
+		WaterMaterial.SetFloat("SunReflectionAmount", map.Water.SunReflection);
 		WaterMaterial.SetFloat("SunShininess", map.Water.SunShininess);
 		WaterMaterial.SetFloat("skyreflectionAmount", map.Water.SkyReflection);
         WaterMaterial.SetFloat("refractionScale", map.Water.RefractionScale);

--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -217,7 +217,7 @@ public partial class ScmapEditor : MonoBehaviour
 		Teren.materialType = Terrain.MaterialType.Custom;
 #endif
 		Teren.materialTemplate = TerrainMaterial;
-		Teren.heightmapPixelError = 4f;
+		Teren.heightmapPixelError = 1f;
 		Teren.basemapDistance = 10000;
 		Teren.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
 		Teren.drawTreesAndFoliage = false;

--- a/Assets/Scripts/Ozone SCMAP Code/Texture/TextureScale.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/Texture/TextureScale.cs
@@ -147,10 +147,8 @@ public class TextureScale
 			NewTex.SetPixels(newColors, m);
 		}
 
-
-		//tex.Resize(newWidth, newHeight);
-		//tex.SetPixels(newColors);
-		NewTex.Apply(true);
+		// Don't recalculate the mipmaps as we have just spent effort to preserve the mipmaps
+		NewTex.Apply(false);
 		return NewTex;
 	}
 

--- a/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
+++ b/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
@@ -224,6 +224,7 @@ namespace EditMap
 
 			if (MapLuaParser.Current.EditMenu.WaterMenu.UseLightingSettings.isOn)
 			{
+				MapLuaParser.Current.EditMenu.WaterMenu.SunDirection = SunDir;
 				MapLuaParser.Current.EditMenu.WaterMenu.WaterSettingsChanged(false);
             }
 

--- a/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
+++ b/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
@@ -265,6 +265,7 @@ namespace EditMap
 		        return;
 	        EnvCube.text = ResourceBrowser.Current.LoadedPaths[ResourceBrowser.DragedObject.InstanceId];
 	        ResourceBrowser.ClearDrag();
+	        UpdateLightingData();
         }
         
         public void ClickSkyCubeButton()

--- a/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
@@ -33,6 +33,7 @@ namespace EditMap
 		public UiTextField SunShininess;
 		public UiTextField UnitReflection;
 		public UiTextField SkyReflection;
+		public UiTextField SunReflection;
 		public UiTextField RefractionScale;
 
 		public InputField WaterRamp;
@@ -93,6 +94,7 @@ namespace EditMap
 			SunShininess.SetValue(ScmapEditor.Current.map.Water.SunShininess);
 			UnitReflection.SetValue(ScmapEditor.Current.map.Water.UnitReflection);
 			SkyReflection.SetValue(ScmapEditor.Current.map.Water.SkyReflection);
+			SunReflection.SetValue(ScmapEditor.Current.map.Water.SunReflection);
 			RefractionScale.SetValue(ScmapEditor.Current.map.Water.RefractionScale);
 
 			WaterRamp.text = ScmapEditor.Current.map.Water.TexPathWaterRamp;
@@ -244,6 +246,7 @@ namespace EditMap
 			ScmapEditor.Current.map.Water.SunShininess = SunShininess.value;
 			ScmapEditor.Current.map.Water.UnitReflection = UnitReflection.value;
 			ScmapEditor.Current.map.Water.SkyReflection = SkyReflection.value;
+			ScmapEditor.Current.map.Water.SunReflection = SunReflection.value;
 			ScmapEditor.Current.map.Water.RefractionScale = RefractionScale.value;
 			
 			ScmapEditor.Current.map.Water.TexPathWaterRamp = WaterRamp.text;
@@ -277,6 +280,7 @@ namespace EditMap
 		        || !Mathf.Approximately(ScmapEditor.Current.map.Water.SunShininess, SunShininess.value)
 		        || !Mathf.Approximately(ScmapEditor.Current.map.Water.UnitReflection, UnitReflection.value)
 		        || !Mathf.Approximately(ScmapEditor.Current.map.Water.SkyReflection, SkyReflection.value)
+		        || !Mathf.Approximately(ScmapEditor.Current.map.Water.SunReflection, SunReflection.value)
 		        || !Mathf.Approximately(ScmapEditor.Current.map.Water.RefractionScale, RefractionScale.value)
 		        || ScmapEditor.Current.map.Water.TexPathWaterRamp != WaterRamp.text
 		        || ScmapEditor.Current.map.Water.TexPathCubemap != Cubemap.text

--- a/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/WaterInfo.cs
@@ -28,7 +28,7 @@ namespace EditMap
 		public UiColor WaterColor;
 		public UiColor SunColor;
 		public Toggle UseLightingSettings;
-		private Vector3 SunDirection;
+		public Vector3 SunDirection;
 
 		public UiTextField SunShininess;
 		public UiTextField UnitReflection;
@@ -88,6 +88,7 @@ namespace EditMap
 
 			WaterColor.SetColorField(ScmapEditor.Current.map.Water.SurfaceColor.x, ScmapEditor.Current.map.Water.SurfaceColor.y, ScmapEditor.Current.map.Water.SurfaceColor.z);
             SunColor.SetColorField(ScmapEditor.Current.map.Water.SunColor.x, ScmapEditor.Current.map.Water.SunColor.y, ScmapEditor.Current.map.Water.SunColor.z);
+            SunDirection.Set(ScmapEditor.Current.map.Water.SunDirection.x, ScmapEditor.Current.map.Water.SunDirection.y, ScmapEditor.Current.map.Water.SunDirection.z);
 
 			SunShininess.SetValue(ScmapEditor.Current.map.Water.SunShininess);
 			UnitReflection.SetValue(ScmapEditor.Current.map.Water.UnitReflection);

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -79,7 +79,7 @@ PlayerSettings:
   androidAutoRotationBehavior: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 1
+  runInBackground: 0
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0


### PR DESCRIPTION
- The calculation of the z component of the normals could lead to artifacts when it evaluated to 0. We now hide them by using the absolute value instead.
- The terrain now preserves more details when zoomed out. The result should be more similar to the experience in the game.
- When you use textures of different resolution in the Layers, they have to be all scaled to the same size internally because they are stored in an array texture. This scaling would lead to a recalculation of mipmaps, so the blurred mipmaps would not be visible anymore, leading to a different look than in the game. Mipmaps are now preserved properly.
- The skycube in the light settings now actually updates when you drag in a texture. The skycube is only visible on unit reflections, so you won't notice an immediate change.
- The sun direction on water reflections now updates properly
- The editor should now pause rendering when it is in the background, saving resources
- The sun reflection setting in the water material was actually a multiplier for the sun reflection amount. It has been removed because its function was unclear and is now added back with a more descriptive name.