### PR TITLE
Fix some props being too bright

### DIFF
--- a/Assets/GFX/Shaders/PropShader.shader
+++ b/Assets/GFX/Shaders/PropShader.shader
@@ -78,7 +78,7 @@ Shader "Custom/PropShader" {
 
 			UNITY_BRANCH
 			if(_GlowAlpha > 0){
-				o.Emission = c.rgb * c.a;
+				o.Emission = 0;
 			}
 			else{
 				clip(c.a * 2 - _Clip);

--- a/Assets/GFX/Shaders/SimpleLambert.cginc
+++ b/Assets/GFX/Shaders/SimpleLambert.cginc
@@ -18,7 +18,8 @@ struct CustomSurfaceOutput
     // this only exists to make the surface shader compile and is unused
     float3 Normal;
 };
-			
+
+// Used by props
 inline float4 LightingSimpleLambertLight(CustomSurfaceOutput s, UnityLight l)
 {
     float4 c;


### PR DESCRIPTION
For some reason props were made to glow, which made some of them brighter in the editor than in the game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced lighting function to the graphics shader system for improved surface rendering and visual quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->