### PR TITLE
Fix low resolution terrain

### DIFF
--- a/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/ScmapEditor.cs
@@ -218,7 +218,7 @@ public partial class ScmapEditor : MonoBehaviour
 		Teren.materialType = Terrain.MaterialType.Custom;
 #endif
 		Teren.materialTemplate = TerrainMaterial;
-		Teren.heightmapPixelError = 1f;
+		Teren.heightmapPixelError = 2f;
 		Teren.basemapDistance = 10000;
 		Teren.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
 		Teren.drawTreesAndFoliage = false;

--- a/Assets/Scripts/UI/Tools/Terrain/TerrainInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/TerrainInfo.cs
@@ -281,7 +281,7 @@ namespace EditMap
 					{
 						if (UpdateBrushPosition(true))
 						{
-							ScmapEditor.Current.Teren.heightmapPixelError = 20;
+							ScmapEditor.Current.Teren.heightmapPixelError = 8;
 							GenerateControlTex.StopGenerateNormal();
 							ScmapEditor.Current.TerrainMaterial.SetInteger("_GeneratingNormal", 1);
 							PaintStarted = true;
@@ -377,7 +377,7 @@ namespace EditMap
 				}
 
 				PaintStarted = false;
-				ScmapEditor.Current.Teren.heightmapPixelError = 4;
+				ScmapEditor.Current.Teren.heightmapPixelError = 2;
 			}
 
 

--- a/Assets/Scripts/UI/Tools/Terrain/TerrainInfo.cs
+++ b/Assets/Scripts/UI/Tools/Terrain/TerrainInfo.cs
@@ -281,7 +281,6 @@ namespace EditMap
 					{
 						if (UpdateBrushPosition(true))
 						{
-							ScmapEditor.Current.Teren.heightmapPixelError = 8;
 							GenerateControlTex.StopGenerateNormal();
 							ScmapEditor.Current.TerrainMaterial.SetInteger("_GeneratingNormal", 1);
 							PaintStarted = true;
@@ -377,7 +376,6 @@ namespace EditMap
 				}
 
 				PaintStarted = false;
-				ScmapEditor.Current.Teren.heightmapPixelError = 2;
 			}
 
 


### PR DESCRIPTION
Unity automatically reduces the mesh resolution of a terrain mesh when you zoom out. To make the mesh still look high resolution we need to use a precomputed normal texture in the shader. This was done in the original shaders, but was lost during the shader rework that got merged into version 0.9 (#42).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimizations**
  * Adjusted terrain heightmap sampling during load to better balance performance and visual quality.
* **Bug Fixes / Stability**
  * Removed temporary detail overrides applied when starting and ending terrain paint to prevent inconsistent rendering during editing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->