### PR TITLE
Adjust map defaults

### DIFF
--- a/Assets/Scripts/HazardX SCMAP Code/Map.cs
+++ b/Assets/Scripts/HazardX SCMAP Code/Map.cs
@@ -262,10 +262,10 @@ public class Map
 		Bloom = 0.03f;
 
 		TerrainShader = "TTerrainXP";
-		LightingMultiplier = 1.6f;
-		SunDirection = new Vector3(0.616f, 0.559f, 0.55473f).normalized;
-		SunAmbience = new Vector3(0.54f, 0.54f, 0.7f);
-		SunColor = new Vector3(1.38f, 1.29f, 1.14f);
+		LightingMultiplier = 1.3f;
+		SunDirection = new Vector3(-0.616f, 0.559f, -0.554f).normalized;
+		SunAmbience = new Vector3(0.41f, 0.44f, 0.55f);
+		SunColor = new Vector3(0.95f, 0.84f, 0.76f);
 		ShadowFillColor = Vector3.zero;
 		SpecularColor = new Vector4(0.1f, 0.1f, 0.1f, 0.1f);
 

--- a/Assets/Scripts/HazardX SCMAP Code/Map.cs
+++ b/Assets/Scripts/HazardX SCMAP Code/Map.cs
@@ -359,9 +359,9 @@ public class Map
 
 			// 9
 			NewLayer = new Layer();
-			NewLayer.PathTexture = "env/evergreen/layers/macrotexture000_albedo.dds";
+			NewLayer.PathTexture = "env/lava/layers/macrotexture000_albedo.dds";
 			NewLayer.PathNormalmap = "";
-			NewLayer.ScaleTexture = 128;
+			NewLayer.ScaleTexture = 180;
 			NewLayer.ScaleNormalmap = 1;
 			Layers.Add(NewLayer);
 		}

--- a/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
+++ b/Assets/Scripts/UI/Tools/Lighting/LightingInfo.cs
@@ -280,9 +280,9 @@ namespace EditMap
 
 			RA.SetValue(312);
 			DA.SetValue(34);
-			LightMultipiler.SetValue(1.6f);
-			LightColor.SetColorField(new Color(1.38f, 1.29f, 1.14f, 1));
-			AmbienceColor.SetColorField(new Color(0.54f, 0.54f, 0.7f));
+			LightMultipiler.SetValue(1.3f);
+			LightColor.SetColorField(new Color(0.95f, 0.84f, 0.76f, 1));
+			AmbienceColor.SetColorField(new Color(0.41f, 0.44f, 0.55f));
 			ShadowColor.SetColorField(Color.black);
 
 			UpdateMenu();


### PR DESCRIPTION
The default lighting was a bit bright

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted global lighting for a warmer, dimmer look and updated default reset lighting values.
  * Reoriented sun lighting direction for improved scene illumination.
  * Swapped terrain texture theme from evergreen to lava and increased texture scale for a different surface detail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->