### PR TITLE
Fix CLI preview rendering

### DIFF
--- a/Assets/Scripts/Camera/CameraControler.cs
+++ b/Assets/Scripts/Camera/CameraControler.cs
@@ -65,29 +65,27 @@ public partial class CameraControler : MonoBehaviour {
 		UpdateRect(NoRect);
 	}
 
-	public void UpdateRect(bool NoRect = false)
-	{
-		float RemoveCamPropHeight = 30f / (float)Screen.height;
-		float RemoveCamPropWidth = 309f / (float)Screen.width;
+public void UpdateRect(bool NoRect = false)
+{
+    float RemoveCamPropHeight = 0;
+    float RemoveCamPropWidth = 0;
 
-		if (NoRect)
-		{
-			RemoveCamPropHeight = 0;
-			RemoveCamPropWidth = 0;
-		}
+    if (!NoRect && Screen.height > 0 && Screen.width > 0)
+    {
+        RemoveCamPropHeight = 30f / (float)Screen.height;
+        RemoveCamPropWidth = 309f / (float)Screen.width;
+    }
 
+    Cam.rect = new Rect(RemoveCamPropWidth, 0, 1 - RemoveCamPropWidth, 1 - RemoveCamPropHeight);
 
+    LastWidth = Screen.width;
+    LastHeight = Screen.height;
 
-		Cam.rect = new Rect(RemoveCamPropWidth, 0, 1 - RemoveCamPropWidth, 1 - RemoveCamPropHeight);
-
-		LastWidth = Screen.width;
-		LastHeight = Screen.height;
-
-		for(int i = 0; i < OtherCams.Length; i++)
-		{
-			OtherCams[i].rect = Cam.rect;
-		}
-	}
+    for(int i = 0; i < OtherCams.Length; i++)
+    {
+        OtherCams[i].rect = Cam.rect;
+    }
+}
 
 	int LastWidth = 0;
 	int LastHeight;
@@ -140,37 +138,17 @@ public partial class CameraControler : MonoBehaviour {
 		return Current.transform.localPosition.y * 10;
 	}
 
-	public IEnumerator RenderCamera(int resWidth, int resHeight, string path){
-		// Set Camera
-		Cam.orthographic = true;
-		Cam.orthographicSize = MapSize * 0.05f;
-		Pivot.localPosition = new Vector3(MapSize * 0.05f, 0, -MapSize * 0.05f);
-		Pivot.rotation = Quaternion.identity;
-		yield return null;
-		// Take Screenshoot
-		RenderTexture rt = new RenderTexture(resWidth, resHeight, 24);
-		Cam.targetTexture = rt;
-		Texture2D screenShot = new Texture2D(resWidth, resHeight, TextureFormat.RGB24, false);
+public IEnumerator RenderCamera(int resWidth, int resHeight, string path){
+    for (int i = 0; i < 5; i++)
+        yield return new WaitForEndOfFrame();
 
-		PreviewTex.ForcePreviewMode(true);
-		Cam.rect = new Rect(0, 0, 1, 1);
-		Cam.Render();
-		PreviewTex.ForcePreviewMode(false);
+    Texture2D screenShot = ScmapEditor.Current.PreviewRenderer.RenderPreview(
+        0f, resWidth, resHeight, false, true
+    );
 
-		RenderTexture.active = rt;
-		screenShot.ReadPixels(new Rect(0, 0, resWidth, resHeight), 0, 0);
-		Cam.targetTexture = null;
-		RenderTexture.active = null; // JC: added to avoid errors
-		Destroy(rt);
-
-		yield return null;
-
-		SaveTexture(screenShot, path);
-
-		// Restart Camera
-		Cam.orthographic = false;
-		RestartCam();
-	}
+    yield return null;
+    SaveTexture(screenShot, path);
+}
 
 	public static void SaveTexture(Texture2D screenShot, string path)
 	{

--- a/Assets/Scripts/Camera/CameraControler.cs
+++ b/Assets/Scripts/Camera/CameraControler.cs
@@ -65,27 +65,27 @@ public partial class CameraControler : MonoBehaviour {
 		UpdateRect(NoRect);
 	}
 
-public void UpdateRect(bool NoRect = false)
-{
-    float RemoveCamPropHeight = 0;
-    float RemoveCamPropWidth = 0;
+	public void UpdateRect(bool NoRect = false)
+	{
+		float RemoveCamPropHeight = 0;
+		float RemoveCamPropWidth = 0;
 
-    if (!NoRect && Screen.height > 0 && Screen.width > 0)
-    {
-        RemoveCamPropHeight = 30f / (float)Screen.height;
-        RemoveCamPropWidth = 309f / (float)Screen.width;
-    }
+		if (!NoRect && Screen.height > 0 && Screen.width > 0)
+		{
+			RemoveCamPropHeight = 30f / (float)Screen.height;
+			RemoveCamPropWidth = 309f / (float)Screen.width;
+		}
 
-    Cam.rect = new Rect(RemoveCamPropWidth, 0, 1 - RemoveCamPropWidth, 1 - RemoveCamPropHeight);
+		Cam.rect = new Rect(RemoveCamPropWidth, 0, 1 - RemoveCamPropWidth, 1 - RemoveCamPropHeight);
 
-    LastWidth = Screen.width;
-    LastHeight = Screen.height;
+		LastWidth = Screen.width;
+		LastHeight = Screen.height;
 
-    for(int i = 0; i < OtherCams.Length; i++)
-    {
-        OtherCams[i].rect = Cam.rect;
-    }
-}
+		for(int i = 0; i < OtherCams.Length; i++)
+		{
+			OtherCams[i].rect = Cam.rect;
+		}
+	}
 
 	int LastWidth = 0;
 	int LastHeight;
@@ -138,17 +138,17 @@ public void UpdateRect(bool NoRect = false)
 		return Current.transform.localPosition.y * 10;
 	}
 
-public IEnumerator RenderCamera(int resWidth, int resHeight, string path){
-    for (int i = 0; i < 5; i++)
-        yield return new WaitForEndOfFrame();
+	public IEnumerator RenderCamera(int resWidth, int resHeight, string path){
+		for (int i = 0; i < 5; i++)
+			yield return new WaitForEndOfFrame();
 
-    Texture2D screenShot = ScmapEditor.Current.PreviewRenderer.RenderPreview(
-        0f, resWidth, resHeight, false, true
-    );
+		Texture2D screenShot = ScmapEditor.Current.PreviewRenderer.RenderPreview(
+			0f, resWidth, resHeight, false, true
+		);
 
-    yield return null;
-    SaveTexture(screenShot, path);
-}
+		yield return null;
+		SaveTexture(screenShot, path);
+	}
 
 	public static void SaveTexture(Texture2D screenShot, string path)
 	{

--- a/Assets/Scripts/Ozone SCMAP Code/MapLuaParser_App.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/MapLuaParser_App.cs
@@ -34,9 +34,6 @@ public partial class MapLuaParser : MonoBehaviour
 		}
 	}
 
-
-
-
 	public IEnumerator RenderImageAndClose(bool Props, bool Decals, int Width, int Height, string MapPath, string ImagePath)
 	{
 		var LoadScmapFile = MapLuaParser.Current.StartCoroutine(ForceLoadMapAtPath(MapPath, Props, Decals));
@@ -53,9 +50,12 @@ public partial class MapLuaParser : MonoBehaviour
 		}
 
 		CameraControler.Current.RestartCam(true);
-		yield return null;
-		CameraControler.Current.RenderCamera(Width, Height, ImagePath);
-		//ScmapEditor.Current.PreviewRenderer.RenderPreview()
+yield return new WaitForEndOfFrame();
+yield return new WaitForEndOfFrame();
+yield return new WaitForEndOfFrame();
+
+yield return CameraControler.Current.StartCoroutine(
+    CameraControler.Current.RenderCamera(Width, Height, ImagePath));
 
 
 		if (Decals)


### PR DESCRIPTION
Fix: CLI -renderPreviewImage never wrote output file, and rendered black when fixed


Problem 1: No output file was produced
When invoking the editor via command line with -renderPreviewImage, the preview PNG was never written to disk. The root cause was in MapLuaParser_App.cs: RenderCamera was called as a plain method instead of as a coroutine, so ForceQuit() killed the process before File.WriteAllBytes could complete.

Fix: Await the coroutine properly:
// Before:
CameraControler.Current.RenderCamera(Width, Height, ImagePath);

// After:
yield return CameraControler.Current.StartCoroutine(CameraControler.Current.RenderCamera(Width, Height, ImagePath));
    

Problem 2: Output was completely black
After fixing the coroutine, the PNG was written but contained only a black image. The cause was that RenderCamera used PreviewTex.ForcePreviewMode(true) + Cam.Render() directly, which only sets a boolean flag but never enables the PREVIEW_ON shader keyword on the terrain material, nor positions the preview camera correctly. In GUI mode this works because the user triggers the render manually after everything is loaded. In CLI mode the render happens immediately, bypassing all the setup that PreviewTex.RenderPreview() performs.
Additionally, UpdateRect() caused a division by zero crash in CLI mode because Screen.height and Screen.width can be 0 before the window is fully initialized.

Fix 1: Use PreviewRenderer.RenderPreview() directly, which handles terrain shader keywords, camera positioning, and render texture setup correctly:
Texture2D screenShot = ScmapEditor.Current.PreviewRenderer.RenderPreview(
    0f, resWidth, resHeight, false, false
);

Fix 2: Guard against division by zero in UpdateRect():
if (!NoRect && Screen.height > 0 && Screen.width > 0)
{
    RemoveCamPropHeight = 30f / (float)Screen.height;
    RemoveCamPropWidth = 309f / (float)Screen.width;
}


Files changed:
Assets/Scripts/Camera/CameraControler.cs
Assets/Scripts/Ozone SCMAP Code/MapLuaParser_App.cs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved camera rendering and preview capture flow for more reliable screenshots and smoother frame handling.
  * Simplified camera rectangle update logic to avoid incorrect dimensions when screen size is zero.

* **Bug Fixes**
  * Prevented unnecessary camera restarts during capture and ensured multi-frame synchronization for consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->