### PR TITLE
Gamedata initial load exception catch

### DIFF
--- a/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Bytes.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Bytes.cs
@@ -7,142 +7,142 @@ using ICSharpCode.SharpZipLib.Zip;
 
 interface IGamedataEntry
 {
-    string Name();
-    byte[] ReadBytes();
+	string Name();
+	byte[] ReadBytes();
 }
 
 public partial struct GetGamedataFile
 {
 
-    //public const string TexturesScd = "textures.scd";
-    //public const string EnvScd = "env.scd";
-    public const string MapScd = "maps";
-    //public const string UnitsScd = "units.scd";
+	//public const string TexturesScd = "textures.scd";
+	//public const string EnvScd = "env.scd";
+	public const string MapScd = "maps";
+	//public const string UnitsScd = "units.scd";
 
-    // Store ZIP Read Stream in memory for faster load
-    //static Dictionary<string, ZipFile> ScdFiles = new Dictionary<string, ZipFile>();
+	// Store ZIP Read Stream in memory for faster load
+	//static Dictionary<string, ZipFile> ScdFiles = new Dictionary<string, ZipFile>();
 
-    static bool gamedataLoaded = false;
-    static Dictionary<string, IGamedataEntry> gamedata = new Dictionary<string, IGamedataEntry>(32768);
-
-
-    public struct GamedataZipEntry : IGamedataEntry
-    {
-        ZipFile zipFile;
-        ZipEntry zipEntry;
-
-        public GamedataZipEntry(ZipFile zipFile, ZipEntry zipEntry)
-        {
-            this.zipFile = zipFile;
-            this.zipEntry = zipEntry;
-        }
-
-        public string Name()
-        {
-            return zipEntry.Name;
-        }
-
-        public byte[] ReadBytes()
-        {
-            //byte[] FinalBytes = new byte[4096]; // 4K is optimum
-            byte[] FinalBytes = new byte[zipEntry.Size];
-            using (Stream s = zipFile.GetInputStream(zipEntry))
-            {
-                s.Read(FinalBytes, 0, FinalBytes.Length);
-                s.Close();
-            }
-            return FinalBytes;
-        }
-    }
-
-    public static void LoadGamedata(bool reload = false)
-    {
-        Initialize();
-
-        if (gamedataLoaded && !reload)
-            return;
-
-        gamedata.Clear();
-
-        if (!EnvPaths.GamedataExist)
-            return;
+	static bool gamedataLoaded = false;
+	static Dictionary<string, IGamedataEntry> gamedata = new Dictionary<string, IGamedataEntry>(32768);
 
 
-        string[] allPaths = EnvPaths.LoadGamedataPaths;
+	public struct GamedataZipEntry : IGamedataEntry
+	{
+		ZipFile zipFile;
+		ZipEntry zipEntry;
 
-        for (int i = 0; i < allPaths.Length; i++)
-        {
-            string path = allPaths[i];
-            if (!Directory.Exists(path))
-            {
-                //Debug.LogWarning("Gamedata scd file could not be found!\n" + path);
-                continue;
-            }
-            var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).Where(s => s.EndsWith(".scd") || s.EndsWith(".nx2"));
+		public GamedataZipEntry(ZipFile zipFile, ZipEntry zipEntry)
+		{
+			this.zipFile = zipFile;
+			this.zipEntry = zipEntry;
+		}
 
-            foreach (string filePath in files)
-            {
-                bool isNx2 = filePath.EndsWith(".nx2");
+		public string Name()
+		{
+			return zipEntry.Name;
+		}
 
+		public byte[] ReadBytes()
+		{
+			//byte[] FinalBytes = new byte[4096]; // 4K is optimum
+			byte[] FinalBytes = new byte[zipEntry.Size];
+			using (Stream s = zipFile.GetInputStream(zipEntry))
+			{
+				s.Read(FinalBytes, 0, FinalBytes.Length);
+				s.Close();
+			}
+			return FinalBytes;
+		}
+	}
 
-                try
-                {
-                    FileStream fs = File.OpenRead(filePath);
-                    ZipFile zipFile = new ZipFile(fs);
-                    int addedFiles = 0;
-                    foreach (ZipEntry ze in zipFile)
-                    {
-                        if (!ze.IsFile)
-                            continue;
+	public static void LoadGamedata(bool reload = false)
+	{
+		Initialize();
 
-                        //string entryPath = ze.Name.ToLower().Replace("\\", "/");
-                        string entryPath = ze.Name.ToLower().Replace("\\", "/");
+		if (gamedataLoaded && !reload)
+			return;
 
-                        if (entryPath.StartsWith("env/") || entryPath.StartsWith("textures/") || entryPath.StartsWith("units/"))
-                        { // Ignore other paths because they will never be used
+		gamedata.Clear();
 
-                            if (gamedata.ContainsKey(entryPath))
-                            {
-                                gamedata[entryPath] = new GamedataZipEntry(zipFile, ze);
-                                addedFiles++;
-                            }
-                            else
-                            {
-                                gamedata.Add(entryPath, new GamedataZipEntry(zipFile, ze));
-                                addedFiles++;
-                                //Debug.Log(ze.Name);
-                            }
-
-                        }
-                    }
-                    if (addedFiles > 0)
-                    {
-                        //	Debug.Log("Load SCD: " + filePath + ", added subfiles: " + addedFiles);
-                    }
-                    else
-                    {
-                        zipFile.Close();
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    Debug.LogError("Error loading file: " + filePath + "\n" + e);
-                    GenericInfoPopup.ShowInfo("Can't load file: " + filePath + " not found in gamedata!");
-                    continue;
-                }
+		if (!EnvPaths.GamedataExist)
+			return;
 
 
-            }
-        }
+		string[] allPaths = EnvPaths.LoadGamedataPaths;
 
-        //TODO Mods
+		for (int i = 0; i < allPaths.Length; i++)
+		{
+			string path = allPaths[i];
+			if (!Directory.Exists(path))
+			{
+				//Debug.LogWarning("Gamedata scd file could not be found!\n" + path);
+				continue;
+			}
+			var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).Where(s => s.EndsWith(".scd") || s.EndsWith(".nx2"));
 
-        gamedataLoaded = true;
+			foreach (string filePath in files)
+			{
+				bool isNx2 = filePath.EndsWith(".nx2");
 
-        Debug.Log("Loaded files from gamedata: " + gamedata.Count);
-    }
 
-    /*public static ZipFile GetZipFileInstance(string scd)
+				try
+				{
+					FileStream fs = File.OpenRead(filePath);
+					ZipFile zipFile = new ZipFile(fs);
+					int addedFiles = 0;
+					foreach (ZipEntry ze in zipFile)
+					{
+						if (!ze.IsFile)
+							continue;
+
+						//string entryPath = ze.Name.ToLower().Replace("\\", "/");
+						string entryPath = ze.Name.ToLower().Replace("\\", "/");
+
+						if (entryPath.StartsWith("env/") || entryPath.StartsWith("textures/") || entryPath.StartsWith("units/"))
+						{ // Ignore other paths because they will never be used
+
+							if (gamedata.ContainsKey(entryPath))
+							{
+								gamedata[entryPath] = new GamedataZipEntry(zipFile, ze);
+								addedFiles++;
+							}
+							else
+							{
+								gamedata.Add(entryPath, new GamedataZipEntry(zipFile, ze));
+								addedFiles++;
+								//Debug.Log(ze.Name);
+							}
+
+						}
+					}
+					if (addedFiles > 0)
+					{
+						//	Debug.Log("Load SCD: " + filePath + ", added subfiles: " + addedFiles);
+					}
+					else
+					{
+						zipFile.Close();
+					}
+				}
+				catch (System.Exception e)
+				{
+					Debug.LogError("Error loading file: " + filePath + "\n" + e);
+					GenericInfoPopup.ShowInfo("Can't load file: " + filePath + " not found in gamedata!");
+					continue;
+				}
+
+
+			}
+		}
+
+		//TODO Mods
+
+		gamedataLoaded = true;
+
+		Debug.Log("Loaded files from gamedata: " + gamedata.Count);
+	}
+
+	/*public static ZipFile GetZipFileInstance(string scd)
 	{
 		Initialize();
 
@@ -164,97 +164,97 @@ public partial struct GetGamedataFile
 	}*/
 
 
-    public static string[] GetFilesInPath(string path)
-    {
-        path = path.ToLower();
-        var files = gamedata.Keys.Where(s => s.StartsWith(path));
-        return files.ToArray();
-    }
+	public static string[] GetFilesInPath(string path)
+	{
+		path = path.ToLower();
+		var files = gamedata.Keys.Where(s => s.StartsWith(path));
+		return files.ToArray();
+	}
 
-    static bool Init = false;
+	static bool Init = false;
 
-    static void Initialize()
-    {
-        if (!Init)
-        {
-            ZipConstants.DefaultCodePage = 0;
-            Init = true;
-        }
-    }
+	static void Initialize()
+	{
+		if (!Init)
+		{
+			ZipConstants.DefaultCodePage = 0;
+			Init = true;
+		}
+	}
 
-    /// <summary>
-    /// Find and return real path from SCD
-    /// </summary>
-    /// <param name="scd"></param>
-    /// <param name="LocalPath"></param>
-    /// <returns></returns>
-    public static string FindFile(string localPath)
-    {
-        localPath = localPath.ToLower();
+	/// <summary>
+	/// Find and return real path from SCD
+	/// </summary>
+	/// <param name="scd"></param>
+	/// <param name="LocalPath"></param>
+	/// <returns></returns>
+	public static string FindFile(string localPath)
+	{
+		localPath = localPath.ToLower();
 
-        if (IsMapPath(localPath))
-        {
-            return localPath;
-        }
-
-
-        if (string.IsNullOrEmpty(localPath))
-        {
-            return localPath;
-        }
+		if (IsMapPath(localPath))
+		{
+			return localPath;
+		}
 
 
-        if (!gamedata.ContainsKey(localPath))
-        {
-            localPath = localPath.ToLower();
-            if (!gamedata.ContainsKey(localPath))
-            {
-                Debug.LogWarning("Can't load file " + localPath);
-                return null;
-            }
-        }
-
-        return gamedata[localPath].Name();
-    }
+		if (string.IsNullOrEmpty(localPath))
+		{
+			return localPath;
+		}
 
 
-    /// <summary>
-    /// Loads bytes from *.scd files from game gamedata folder. Returns decompressed bytes of that file.
-    /// </summary>
-    /// <param name="scd"></param>
-    /// <param name="LocalPath"></param>
-    /// <returns></returns>
-    public static byte[] LoadBytes(string LocalPath)
-    {
-        if (IsMapPath(LocalPath))
-        {
-            return LoadMapBytes(LocalPath);
-        }
+		if (!gamedata.ContainsKey(localPath))
+		{
+			localPath = localPath.ToLower();
+			if (!gamedata.ContainsKey(localPath))
+			{
+				Debug.LogWarning("Can't load file " + localPath);
+				return null;
+			}
+		}
 
-        if (string.IsNullOrEmpty(LocalPath)) return null;
+		return gamedata[localPath].Name();
+	}
 
-        if (!Directory.Exists(EnvPaths.CurrentGamedataPath))
-        {
-            Debug.LogWarning("Gamedata path dont exist!");
-            return null;
-        }
 
-        if (LocalPath.StartsWith("/"))
-            LocalPath = LocalPath.Remove(0, 1);
+	/// <summary>
+	/// Loads bytes from *.scd files from game gamedata folder. Returns decompressed bytes of that file.
+	/// </summary>
+	/// <param name="scd"></param>
+	/// <param name="LocalPath"></param>
+	/// <returns></returns>
+	public static byte[] LoadBytes(string LocalPath)
+	{
+		if (IsMapPath(LocalPath))
+		{
+			return LoadMapBytes(LocalPath);
+		}
 
-        if (!gamedata.ContainsKey(LocalPath))
-        {
-            LocalPath = LocalPath.ToLower();
-            if (!gamedata.ContainsKey(LocalPath))
-            {
-                return null;
-            }
-        }
+		if (string.IsNullOrEmpty(LocalPath)) return null;
 
-        return gamedata[LocalPath].ReadBytes();
-    }
+		if (!Directory.Exists(EnvPaths.CurrentGamedataPath))
+		{
+			Debug.LogWarning("Gamedata path dont exist!");
+			return null;
+		}
 
-    /*static byte[] ReadZipEntryBytes(ZipEntry ze, ZipFile File)
+		if (LocalPath.StartsWith("/"))
+			LocalPath = LocalPath.Remove(0, 1);
+
+		if (!gamedata.ContainsKey(LocalPath))
+		{
+			LocalPath = LocalPath.ToLower();
+			if (!gamedata.ContainsKey(LocalPath))
+			{
+				return null;
+			}
+		}
+
+		return gamedata[LocalPath].ReadBytes();
+	}
+
+	/*static byte[] ReadZipEntryBytes(ZipEntry ze, ZipFile File)
 	{
 		//byte[] FinalBytes = new byte[4096]; // 4K is optimum
 		Stream s = File.GetInputStream(ze);
@@ -266,112 +266,112 @@ public partial struct GetGamedataFile
 	}*/
 
 
-    /// <summary>
-    /// Load Bytes from files in Map folder
-    /// </summary>
-    /// <param name="mapPath"></param>
-    /// <returns></returns>
-    public static byte[] LoadMapBytes(string mapPath)
-    {
-        if (!mapPath.StartsWith("/"))
-            mapPath = "/" + mapPath;
+	/// <summary>
+	/// Load Bytes from files in Map folder
+	/// </summary>
+	/// <param name="mapPath"></param>
+	/// <returns></returns>
+	public static byte[] LoadMapBytes(string mapPath)
+	{
+		if (!mapPath.StartsWith("/"))
+			mapPath = "/" + mapPath;
 
-        string FilePath = MapAssetSystemPath(mapPath);
+		string FilePath = MapAssetSystemPath(mapPath);
 
-        if (!File.Exists(FilePath))
-        {
+		if (!File.Exists(FilePath))
+		{
 
-            mapPath = TryRecoverMapAsset(mapPath);
-            FilePath = MapAssetSystemPath(mapPath);
+			mapPath = TryRecoverMapAsset(mapPath);
+			FilePath = MapAssetSystemPath(mapPath);
 
-            if (!File.Exists(FilePath))
-            {
-                Debug.LogWarning("File does not exist! " + FilePath);
-                return null;
-            }
-            else
-            {
-                Debug.Log("File " + FilePath + " restored from old map folder!");
-            }
-        }
+			if (!File.Exists(FilePath))
+			{
+				Debug.LogWarning("File does not exist! " + FilePath);
+				return null;
+			}
+			else
+			{
+				Debug.Log("File " + FilePath + " restored from old map folder!");
+			}
+		}
 
-        return File.ReadAllBytes(FilePath);
-    }
+		return File.ReadAllBytes(FilePath);
+	}
 
-    #region Map folder path
+	#region Map folder path
 
-    public static bool IsMapPath(string mapPath)
-    {
-        mapPath = mapPath.ToLower();
-        if (!mapPath.StartsWith("/"))
-            mapPath = "/" + mapPath;
+	public static bool IsMapPath(string mapPath)
+	{
+		mapPath = mapPath.ToLower();
+		if (!mapPath.StartsWith("/"))
+			mapPath = "/" + mapPath;
 
-        return mapPath.StartsWith("/maps");
-    }
+		return mapPath.StartsWith("/maps");
+	}
 
-    public static string MapAssetSystemPath(string mapPath)
-    {
-        if (!mapPath.StartsWith("/"))
-            mapPath = "/" + mapPath;
+	public static string MapAssetSystemPath(string mapPath)
+	{
+		if (!mapPath.StartsWith("/"))
+			mapPath = "/" + mapPath;
 
-        return mapPath.Replace("/maps", MapLuaParser.Current.FolderParentPath);
-    }
+		return mapPath.Replace("/maps", MapLuaParser.Current.FolderParentPath);
+	}
 
-    public static string TryRecoverMapAsset(string WrongPath)
-    {
-        bool StartChar = false;
-        if (WrongPath.StartsWith("/"))
-        {
-            StartChar = true;
-            WrongPath = WrongPath.Remove(0, 1);
-        }
+	public static string TryRecoverMapAsset(string WrongPath)
+	{
+		bool StartChar = false;
+		if (WrongPath.StartsWith("/"))
+		{
+			StartChar = true;
+			WrongPath = WrongPath.Remove(0, 1);
+		}
 
-        WrongPath = WrongPath.Replace("\\", "/");
+		WrongPath = WrongPath.Replace("\\", "/");
 
-        string NewPath = "";
-        try
-        {
-            string[] SplitedName = WrongPath.Split('/');
-            SplitedName[1] = MapLuaParser.Current.FolderName;
+		string NewPath = "";
+		try
+		{
+			string[] SplitedName = WrongPath.Split('/');
+			SplitedName[1] = MapLuaParser.Current.FolderName;
 
 
-            for (int i = 0; i < SplitedName.Length; i++)
-            {
-                if (i > 0)
-                    NewPath += "/";
-                NewPath += SplitedName[i];
-            }
-        }
-        catch (System.Exception e)
-        {
-            Debug.LogError(e);
-        }
-        return (StartChar ? "/" : "") + NewPath;
-    }
+			for (int i = 0; i < SplitedName.Length; i++)
+			{
+				if (i > 0)
+					NewPath += "/";
+				NewPath += SplitedName[i];
+			}
+		}
+		catch (System.Exception e)
+		{
+			Debug.LogError(e);
+		}
+		return (StartChar ? "/" : "") + NewPath;
+	}
 
-    public static string FixMapsPath(string BlueprintPath)
-    {
-        if (IsMapPath(BlueprintPath))
-        {
-            //Debug.Log(MapLuaParser.Current.FolderName);
-            if (!BlueprintPath.StartsWith("/maps/" + MapLuaParser.Current.FolderName) && !BlueprintPath.StartsWith("maps/" + MapLuaParser.Current.FolderName))
-            {
-                //if (!System.IO.File.Exists(GetGamedataFile.MapAssetSystemPath(BlueprintPath)))
-                //{
-                string NewBlueprintPath = TryRecoverMapAsset(BlueprintPath);
-                Debug.Log("Before: " + BlueprintPath + ", after: " + NewBlueprintPath);
+	public static string FixMapsPath(string BlueprintPath)
+	{
+		if (IsMapPath(BlueprintPath))
+		{
+			//Debug.Log(MapLuaParser.Current.FolderName);
+			if (!BlueprintPath.StartsWith("/maps/" + MapLuaParser.Current.FolderName) && !BlueprintPath.StartsWith("maps/" + MapLuaParser.Current.FolderName))
+			{
+				//if (!System.IO.File.Exists(GetGamedataFile.MapAssetSystemPath(BlueprintPath)))
+				//{
+				string NewBlueprintPath = TryRecoverMapAsset(BlueprintPath);
+				Debug.Log("Before: " + BlueprintPath + ", after: " + NewBlueprintPath);
 
-                if (!string.IsNullOrEmpty(NewBlueprintPath))
-                {
-                    return NewBlueprintPath;
-                }
-                else
-                {
-                    Debug.LogError("Unable to recover wrong map path: " + BlueprintPath);
-                }
-            }
-        }
-        return BlueprintPath;
-    }
-    #endregion
+				if (!string.IsNullOrEmpty(NewBlueprintPath))
+				{
+					return NewBlueprintPath;
+				}
+				else
+				{
+					Debug.LogError("Unable to recover wrong map path: " + BlueprintPath);
+				}
+			}
+		}
+		return BlueprintPath;
+	}
+	#endregion
 }

--- a/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Bytes.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Bytes.cs
@@ -7,132 +7,142 @@ using ICSharpCode.SharpZipLib.Zip;
 
 interface IGamedataEntry
 {
-	string Name();
-	byte[] ReadBytes();
+    string Name();
+    byte[] ReadBytes();
 }
 
 public partial struct GetGamedataFile
 {
 
-	//public const string TexturesScd = "textures.scd";
-	//public const string EnvScd = "env.scd";
-	public const string MapScd = "maps";
-	//public const string UnitsScd = "units.scd";
+    //public const string TexturesScd = "textures.scd";
+    //public const string EnvScd = "env.scd";
+    public const string MapScd = "maps";
+    //public const string UnitsScd = "units.scd";
 
-	// Store ZIP Read Stream in memory for faster load
-	//static Dictionary<string, ZipFile> ScdFiles = new Dictionary<string, ZipFile>();
+    // Store ZIP Read Stream in memory for faster load
+    //static Dictionary<string, ZipFile> ScdFiles = new Dictionary<string, ZipFile>();
 
-	static bool gamedataLoaded = false;
-	static Dictionary<string, IGamedataEntry> gamedata = new Dictionary<string, IGamedataEntry>(32768);
-
-
-	public struct GamedataZipEntry : IGamedataEntry
-	{
-		ZipFile zipFile;
-		ZipEntry zipEntry;
-
-		public GamedataZipEntry(ZipFile zipFile, ZipEntry zipEntry)
-		{
-			this.zipFile = zipFile;
-			this.zipEntry = zipEntry;
-		}
-
-		public string Name()
-		{
-			return zipEntry.Name;
-		}
-
-		public byte[] ReadBytes()
-		{
-			//byte[] FinalBytes = new byte[4096]; // 4K is optimum
-			byte[] FinalBytes = new byte[zipEntry.Size];
-			using (Stream s = zipFile.GetInputStream(zipEntry))
-			{
-				s.Read(FinalBytes, 0, FinalBytes.Length);
-				s.Close();
-			}
-			return FinalBytes;
-		}
-	}
-
-	public static void LoadGamedata(bool reload = false)
-	{
-		Initialize();
-
-		if (gamedataLoaded && !reload)
-			return;
-
-		gamedata.Clear();
-
-		if (!EnvPaths.GamedataExist)
-			return;
+    static bool gamedataLoaded = false;
+    static Dictionary<string, IGamedataEntry> gamedata = new Dictionary<string, IGamedataEntry>(32768);
 
 
-		string[] allPaths = EnvPaths.LoadGamedataPaths;
+    public struct GamedataZipEntry : IGamedataEntry
+    {
+        ZipFile zipFile;
+        ZipEntry zipEntry;
 
-		for(int i = 0; i < allPaths.Length; i++)
-		{
-			string path = allPaths[i];
-			if (!Directory.Exists(path))
-			{
-				//Debug.LogWarning("Gamedata scd file could not be found!\n" + path);
-				continue;
-			}
-			var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).Where(s => s.EndsWith(".scd") || s.EndsWith(".nx2"));
+        public GamedataZipEntry(ZipFile zipFile, ZipEntry zipEntry)
+        {
+            this.zipFile = zipFile;
+            this.zipEntry = zipEntry;
+        }
 
-			foreach(string filePath in files)
-			{
-				bool isNx2 = filePath.EndsWith(".nx2");
+        public string Name()
+        {
+            return zipEntry.Name;
+        }
+
+        public byte[] ReadBytes()
+        {
+            //byte[] FinalBytes = new byte[4096]; // 4K is optimum
+            byte[] FinalBytes = new byte[zipEntry.Size];
+            using (Stream s = zipFile.GetInputStream(zipEntry))
+            {
+                s.Read(FinalBytes, 0, FinalBytes.Length);
+                s.Close();
+            }
+            return FinalBytes;
+        }
+    }
+
+    public static void LoadGamedata(bool reload = false)
+    {
+        Initialize();
+
+        if (gamedataLoaded && !reload)
+            return;
+
+        gamedata.Clear();
+
+        if (!EnvPaths.GamedataExist)
+            return;
 
 
-				FileStream fs = File.OpenRead(filePath);
-				ZipFile zipFile = new ZipFile(fs);
-				int addedFiles = 0;
-				foreach(ZipEntry ze in zipFile)
-				{
-					if (!ze.IsFile)
-						continue;
+        string[] allPaths = EnvPaths.LoadGamedataPaths;
 
-					//string entryPath = ze.Name.ToLower().Replace("\\", "/");
-					string entryPath = ze.Name.ToLower().Replace("\\", "/");
+        for (int i = 0; i < allPaths.Length; i++)
+        {
+            string path = allPaths[i];
+            if (!Directory.Exists(path))
+            {
+                //Debug.LogWarning("Gamedata scd file could not be found!\n" + path);
+                continue;
+            }
+            var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).Where(s => s.EndsWith(".scd") || s.EndsWith(".nx2"));
 
-					if (entryPath.StartsWith("env/") || entryPath.StartsWith("textures/") || entryPath.StartsWith("units/"))
-					{ // Ignore other paths because they will never be used
+            foreach (string filePath in files)
+            {
+                bool isNx2 = filePath.EndsWith(".nx2");
 
-						if (gamedata.ContainsKey(entryPath))
-						{
-							gamedata[entryPath] = new GamedataZipEntry(zipFile, ze);
-							addedFiles++;
-						}
-						else
-						{
-							gamedata.Add(entryPath, new GamedataZipEntry(zipFile, ze));
-							addedFiles++;
-							//Debug.Log(ze.Name);
-						}
 
-					}
-				}
-				if (addedFiles > 0)
-				{
-				//	Debug.Log("Load SCD: " + filePath + ", added subfiles: " + addedFiles);
-				}
-				else
-				{
-					zipFile.Close();
-				}
+                try
+                {
+                    FileStream fs = File.OpenRead(filePath);
+                    ZipFile zipFile = new ZipFile(fs);
+                    int addedFiles = 0;
+                    foreach (ZipEntry ze in zipFile)
+                    {
+                        if (!ze.IsFile)
+                            continue;
 
-			}
-		}
+                        //string entryPath = ze.Name.ToLower().Replace("\\", "/");
+                        string entryPath = ze.Name.ToLower().Replace("\\", "/");
 
-		//TODO Mods
+                        if (entryPath.StartsWith("env/") || entryPath.StartsWith("textures/") || entryPath.StartsWith("units/"))
+                        { // Ignore other paths because they will never be used
 
-		gamedataLoaded = true;
+                            if (gamedata.ContainsKey(entryPath))
+                            {
+                                gamedata[entryPath] = new GamedataZipEntry(zipFile, ze);
+                                addedFiles++;
+                            }
+                            else
+                            {
+                                gamedata.Add(entryPath, new GamedataZipEntry(zipFile, ze));
+                                addedFiles++;
+                                //Debug.Log(ze.Name);
+                            }
 
-		Debug.Log("Loaded files from gamedata: " + gamedata.Count);
-	}
+                        }
+                    }
+                    if (addedFiles > 0)
+                    {
+                        //	Debug.Log("Load SCD: " + filePath + ", added subfiles: " + addedFiles);
+                    }
+                    else
+                    {
+                        zipFile.Close();
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    Debug.LogError("Error loading file: " + filePath + "\n" + e);
+                    GenericInfoPopup.ShowInfo("Can't load file: " + filePath + " not found in gamedata!");
+                    continue;
+                }
 
-	/*public static ZipFile GetZipFileInstance(string scd)
+
+            }
+        }
+
+        //TODO Mods
+
+        gamedataLoaded = true;
+
+        Debug.Log("Loaded files from gamedata: " + gamedata.Count);
+    }
+
+    /*public static ZipFile GetZipFileInstance(string scd)
 	{
 		Initialize();
 
@@ -154,97 +164,97 @@ public partial struct GetGamedataFile
 	}*/
 
 
-	public static string[] GetFilesInPath(string path)
-	{
-		path = path.ToLower();
-		var files = gamedata.Keys.Where(s => s.StartsWith(path));
-		return files.ToArray();
-	}
+    public static string[] GetFilesInPath(string path)
+    {
+        path = path.ToLower();
+        var files = gamedata.Keys.Where(s => s.StartsWith(path));
+        return files.ToArray();
+    }
 
-	static bool Init = false;
+    static bool Init = false;
 
-	static void Initialize()
-	{
-		if (!Init)
-		{
-			ZipConstants.DefaultCodePage = 0;
-			Init = true;
-		}
-	}
+    static void Initialize()
+    {
+        if (!Init)
+        {
+            ZipConstants.DefaultCodePage = 0;
+            Init = true;
+        }
+    }
 
-	/// <summary>
-	/// Find and return real path from SCD
-	/// </summary>
-	/// <param name="scd"></param>
-	/// <param name="LocalPath"></param>
-	/// <returns></returns>
-	public static string FindFile(string localPath)
-	{
-		localPath = localPath.ToLower();
+    /// <summary>
+    /// Find and return real path from SCD
+    /// </summary>
+    /// <param name="scd"></param>
+    /// <param name="LocalPath"></param>
+    /// <returns></returns>
+    public static string FindFile(string localPath)
+    {
+        localPath = localPath.ToLower();
 
-		if (IsMapPath(localPath))
-		{
-			return localPath;
-		}
-
-
-		if (string.IsNullOrEmpty(localPath))
-		{
-			return localPath;
-		}
+        if (IsMapPath(localPath))
+        {
+            return localPath;
+        }
 
 
-		if (!gamedata.ContainsKey(localPath))
-		{
-			localPath = localPath.ToLower();
-			if (!gamedata.ContainsKey(localPath))
-			{
-				Debug.LogWarning("Can't load file " + localPath);
-				return null;
-			}
-		}
-
-		return gamedata[localPath].Name();
-	}
+        if (string.IsNullOrEmpty(localPath))
+        {
+            return localPath;
+        }
 
 
-	/// <summary>
-	/// Loads bytes from *.scd files from game gamedata folder. Returns decompressed bytes of that file.
-	/// </summary>
-	/// <param name="scd"></param>
-	/// <param name="LocalPath"></param>
-	/// <returns></returns>
-	public static byte[] LoadBytes(string LocalPath)
-	{
-		if (IsMapPath(LocalPath))
-		{
-			return LoadMapBytes(LocalPath); 
-		}
+        if (!gamedata.ContainsKey(localPath))
+        {
+            localPath = localPath.ToLower();
+            if (!gamedata.ContainsKey(localPath))
+            {
+                Debug.LogWarning("Can't load file " + localPath);
+                return null;
+            }
+        }
 
-		if (string.IsNullOrEmpty(LocalPath)) return null;
+        return gamedata[localPath].Name();
+    }
 
-		if (!Directory.Exists(EnvPaths.CurrentGamedataPath))
-		{
-			Debug.LogWarning("Gamedata path dont exist!");
-			return null;
-		}
 
-		if (LocalPath.StartsWith("/"))
-			LocalPath = LocalPath.Remove(0, 1);
+    /// <summary>
+    /// Loads bytes from *.scd files from game gamedata folder. Returns decompressed bytes of that file.
+    /// </summary>
+    /// <param name="scd"></param>
+    /// <param name="LocalPath"></param>
+    /// <returns></returns>
+    public static byte[] LoadBytes(string LocalPath)
+    {
+        if (IsMapPath(LocalPath))
+        {
+            return LoadMapBytes(LocalPath);
+        }
 
-		if (!gamedata.ContainsKey(LocalPath))
-		{
-			LocalPath = LocalPath.ToLower();
-			if (!gamedata.ContainsKey(LocalPath))
-			{
-				return null;
-			}
-		}
+        if (string.IsNullOrEmpty(LocalPath)) return null;
 
-		return gamedata[LocalPath].ReadBytes();
-	}
+        if (!Directory.Exists(EnvPaths.CurrentGamedataPath))
+        {
+            Debug.LogWarning("Gamedata path dont exist!");
+            return null;
+        }
 
-	/*static byte[] ReadZipEntryBytes(ZipEntry ze, ZipFile File)
+        if (LocalPath.StartsWith("/"))
+            LocalPath = LocalPath.Remove(0, 1);
+
+        if (!gamedata.ContainsKey(LocalPath))
+        {
+            LocalPath = LocalPath.ToLower();
+            if (!gamedata.ContainsKey(LocalPath))
+            {
+                return null;
+            }
+        }
+
+        return gamedata[LocalPath].ReadBytes();
+    }
+
+    /*static byte[] ReadZipEntryBytes(ZipEntry ze, ZipFile File)
 	{
 		//byte[] FinalBytes = new byte[4096]; // 4K is optimum
 		Stream s = File.GetInputStream(ze);
@@ -256,112 +266,112 @@ public partial struct GetGamedataFile
 	}*/
 
 
-	/// <summary>
-	/// Load Bytes from files in Map folder
-	/// </summary>
-	/// <param name="mapPath"></param>
-	/// <returns></returns>
-	public static byte[] LoadMapBytes(string mapPath)
-	{
-		if (!mapPath.StartsWith("/"))
-			mapPath = "/" + mapPath;
+    /// <summary>
+    /// Load Bytes from files in Map folder
+    /// </summary>
+    /// <param name="mapPath"></param>
+    /// <returns></returns>
+    public static byte[] LoadMapBytes(string mapPath)
+    {
+        if (!mapPath.StartsWith("/"))
+            mapPath = "/" + mapPath;
 
-		string FilePath = MapAssetSystemPath(mapPath);
+        string FilePath = MapAssetSystemPath(mapPath);
 
-		if (!File.Exists(FilePath))
-		{
+        if (!File.Exists(FilePath))
+        {
 
-			mapPath = TryRecoverMapAsset(mapPath);
-			FilePath = MapAssetSystemPath(mapPath);
+            mapPath = TryRecoverMapAsset(mapPath);
+            FilePath = MapAssetSystemPath(mapPath);
 
-			if (!File.Exists(FilePath))
-			{
-				Debug.LogWarning("File does not exist! " + FilePath);
-				return null;
-			}
-			else
-			{
-				Debug.Log("File " + FilePath + " restored from old map folder!");
-			}
-		}
+            if (!File.Exists(FilePath))
+            {
+                Debug.LogWarning("File does not exist! " + FilePath);
+                return null;
+            }
+            else
+            {
+                Debug.Log("File " + FilePath + " restored from old map folder!");
+            }
+        }
 
-		return File.ReadAllBytes(FilePath);
-	}
+        return File.ReadAllBytes(FilePath);
+    }
 
-	#region Map folder path
+    #region Map folder path
 
-	public static bool IsMapPath(string mapPath)
-	{
-		mapPath = mapPath.ToLower();
-		if (!mapPath.StartsWith("/"))
-			mapPath = "/" + mapPath;
+    public static bool IsMapPath(string mapPath)
+    {
+        mapPath = mapPath.ToLower();
+        if (!mapPath.StartsWith("/"))
+            mapPath = "/" + mapPath;
 
-		return mapPath.StartsWith("/maps");
-	}
+        return mapPath.StartsWith("/maps");
+    }
 
-	public static string MapAssetSystemPath(string mapPath)
-	{
-		if (!mapPath.StartsWith("/"))
-			mapPath = "/" + mapPath;
+    public static string MapAssetSystemPath(string mapPath)
+    {
+        if (!mapPath.StartsWith("/"))
+            mapPath = "/" + mapPath;
 
-		return mapPath.Replace("/maps", MapLuaParser.Current.FolderParentPath);
-	}
+        return mapPath.Replace("/maps", MapLuaParser.Current.FolderParentPath);
+    }
 
-	public static string TryRecoverMapAsset(string WrongPath)
-	{
-		bool StartChar = false;
-		if (WrongPath.StartsWith("/"))
-		{
-			StartChar = true;
-			WrongPath = WrongPath.Remove(0, 1);
-		}
+    public static string TryRecoverMapAsset(string WrongPath)
+    {
+        bool StartChar = false;
+        if (WrongPath.StartsWith("/"))
+        {
+            StartChar = true;
+            WrongPath = WrongPath.Remove(0, 1);
+        }
 
-		WrongPath = WrongPath.Replace("\\", "/");
+        WrongPath = WrongPath.Replace("\\", "/");
 
-		string NewPath = "";
-		try
-		{
-			string[] SplitedName = WrongPath.Split('/');
-			SplitedName[1] = MapLuaParser.Current.FolderName;
+        string NewPath = "";
+        try
+        {
+            string[] SplitedName = WrongPath.Split('/');
+            SplitedName[1] = MapLuaParser.Current.FolderName;
 
 
-			for(int i = 0; i < SplitedName.Length; i++)
-			{
-				if (i > 0)
-					NewPath += "/";
-				NewPath += SplitedName[i];
-			}
-		}
-		catch (System.Exception e)
-		{
-			Debug.LogError(e);
-		}
-		return (StartChar?"/":"") +  NewPath;
-	}
+            for (int i = 0; i < SplitedName.Length; i++)
+            {
+                if (i > 0)
+                    NewPath += "/";
+                NewPath += SplitedName[i];
+            }
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError(e);
+        }
+        return (StartChar ? "/" : "") + NewPath;
+    }
 
-	public static string FixMapsPath(string BlueprintPath)
-	{
-		if (IsMapPath(BlueprintPath))
-		{
-			//Debug.Log(MapLuaParser.Current.FolderName);
-			if (!BlueprintPath.StartsWith("/maps/" + MapLuaParser.Current.FolderName) && !BlueprintPath.StartsWith("maps/" + MapLuaParser.Current.FolderName))
-			{ 
-			//if (!System.IO.File.Exists(GetGamedataFile.MapAssetSystemPath(BlueprintPath)))
-			//{
-				string NewBlueprintPath = TryRecoverMapAsset(BlueprintPath);
-				Debug.Log("Before: " + BlueprintPath + ", after: " + NewBlueprintPath);
+    public static string FixMapsPath(string BlueprintPath)
+    {
+        if (IsMapPath(BlueprintPath))
+        {
+            //Debug.Log(MapLuaParser.Current.FolderName);
+            if (!BlueprintPath.StartsWith("/maps/" + MapLuaParser.Current.FolderName) && !BlueprintPath.StartsWith("maps/" + MapLuaParser.Current.FolderName))
+            {
+                //if (!System.IO.File.Exists(GetGamedataFile.MapAssetSystemPath(BlueprintPath)))
+                //{
+                string NewBlueprintPath = TryRecoverMapAsset(BlueprintPath);
+                Debug.Log("Before: " + BlueprintPath + ", after: " + NewBlueprintPath);
 
-				if (!string.IsNullOrEmpty(NewBlueprintPath))
-				{
-					return NewBlueprintPath;
-				}
-				else
-				{
-					Debug.LogError("Unable to recover wrong map path: " + BlueprintPath);
-				}
-			}
-		}
-		return BlueprintPath;
-	}
-	#endregion
+                if (!string.IsNullOrEmpty(NewBlueprintPath))
+                {
+                    return NewBlueprintPath;
+                }
+                else
+                {
+                    Debug.LogError("Unable to recover wrong map path: " + BlueprintPath);
+                }
+            }
+        }
+        return BlueprintPath;
+    }
+    #endregion
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gamedata loading robustness: when an individual gamedata file fails, the error is logged, a user-facing notification is shown, and loading continues with the next file instead of aborting.
  * Preserved existing file selection and replace-on-conflict behavior so loaded content remains consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->